### PR TITLE
Enhance post transitions

### DIFF
--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -1,24 +1,63 @@
-import { getPostById } from "@/lib/posts";
-import { notFound } from "next/navigation";
-export default async function PostPage({ params }: { params: { id: string } }) {
-  const { id: idParam } = await params;
-  const id = Number(idParam);
-  const post = await getPostById(id);
+"use client";
 
-  if (!post) return notFound();
+import { getPostById, getNextPosts } from "@/lib/posts";
+import { useRouter } from "next/navigation";
+
+export default function PostPage({ params }: { params: { id: string } }) {
+  const router = useRouter();
+  const id = Number(params.id);
+  const post = getPostById(id);
+  const nextPosts = getNextPosts(id, 3);
+
+  const navigate = (postId: number) => {
+    document.startViewTransition(() => {
+      router.push(`/posts/${postId}`);
+    });
+  };
 
   return (
-    <article className="mx-auto max-w-xl p-4">
-      <h1 className="mb-2 text-2xl font-bold">{post.title}</h1>
-      <p className="text-sm text-gray-500">
-        {new Date(post.date).toDateString()}
-      </p>
-      <img
-        src={post.image}
-        alt={post.title}
-        className="my-4 w-full rounded-md"
-      />
-      <p>{post.content}</p>
-    </article>
+    <div className="mx-auto flex max-w-5xl p-4">
+      <article className="flex-1">
+        <button
+          onClick={() => router.back()}
+          className="mb-4 text-sm text-blue-500"
+        >
+          &larr; Back
+        </button>
+        <h1 className="mb-2 text-2xl font-bold">{post.title}</h1>
+        <p className="text-sm text-gray-500">
+          {new Date(post.date).toDateString()}
+        </p>
+        <div style={{ viewTransitionName: `post-${post.id}` }}>
+          <img
+            src={post.image}
+            alt={post.title}
+            className="my-4 w-full rounded-md"
+          />
+        </div>
+        <p>{post.content}</p>
+      </article>
+      <aside className="ml-8 hidden w-64 space-y-4 md:block">
+        {nextPosts.map((p) => (
+          <div
+            key={p.id}
+            onClick={() => navigate(p.id)}
+            className="cursor-pointer"
+          >
+            <div
+              style={{ viewTransitionName: `post-${p.id}`, height: 80 }}
+              className="overflow-hidden rounded-md bg-gray-100"
+            >
+              <img
+                src={p.image}
+                alt={p.title}
+                className="h-full w-full object-cover"
+              />
+            </div>
+            <h3 className="mt-1 text-sm">{p.title}</h3>
+          </div>
+        ))}
+      </aside>
+    </div>
   );
 }

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import type { Post } from "@/lib/posts";
 
 interface Props {
@@ -10,12 +9,9 @@ export default function PostCard({ post }: Props) {
   const height = 150 + (post.id % 3) * 50;
 
   return (
-    <Link
-      href={`/posts/${post.id}`}
-      className="mb-4 block w-full transition-opacity hover:opacity-80"
-    >
+    <div className="mb-4 block w-full transition-opacity hover:opacity-80">
       <div
-        style={{ height }}
+        style={{ height, viewTransitionName: `post-${post.id}` }}
         className="relative w-full overflow-hidden rounded-lg bg-gray-100"
       >
         {post.image ? (
@@ -28,6 +24,6 @@ export default function PostCard({ post }: Props) {
           <h3 className="mt-2 text-sm font-medium">{post.title}</h3>
         )}
       </div>
-    </Link>
+    </div>
   );
 }

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -24,3 +24,7 @@ export function getPosts(page: number, limit: number): Post[] {
 export function getPostById(id: number): Post {
   return mockPost(id);
 }
+
+export function getNextPosts(startId: number, limit: number): Post[] {
+  return Array.from({ length: limit }, (_, i) => mockPost(startId + i + 1));
+}


### PR DESCRIPTION
## Summary
- add view transition style to `PostCard`
- expose `getNextPosts` helper
- rewrite post page as client component with back button, next posts sidebar, and transition navigation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846cedc7660832088c80d57829ca880