### PR TITLE
Improve login/signup and add navigation

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
+import Navbar from "@/components/Navbar";
 
 const pretendard = localFont({
   src: [
@@ -30,7 +31,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={`${pretendard.variable} antialiased`}>{children}</body>
+      <body className={`${pretendard.variable} antialiased`}>
+        <Navbar />
+        <main className="pt-4">{children}</main>
+      </body>
     </html>
   );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { login } from '@/lib/auth';
 import { Button } from '@/components/ui/button';
@@ -24,28 +25,51 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="flex flex-col items-center justify-center h-[60vh] gap-4">
-      <h1 className="text-2xl font-bold">Login</h1>
-      <form onSubmit={handleSubmit} className="w-full max-w-xs space-y-2">
-        <Input
-          type="email"
-          placeholder="Email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          required
-        />
-        <Input
-          type="password"
-          placeholder="Password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          required
-        />
-        {error && <p className="text-red-500 text-sm">{error}</p>}
-        <Button type="submit" className="w-full">
-          Login
-        </Button>
-      </form>
+    <div className="flex justify-center">
+      <div className="w-full max-w-md py-10 space-y-6">
+        <h1 className="text-2xl font-bold text-center">Welcome Back!</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1">
+            <label htmlFor="email" className="block text-sm font-medium">
+              Email
+            </label>
+            <Input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-1">
+            <label htmlFor="password" className="block text-sm font-medium">
+              Password
+            </label>
+            <Input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </div>
+          {error && <p className="text-red-500 text-sm">{error}</p>}
+          <Button type="submit" className="w-full">
+            Login
+          </Button>
+        </form>
+        <div className="flex items-center gap-2 text-sm text-gray-500">
+          <span className="h-px flex-1 bg-gray-300" />
+          OR
+          <span className="h-px flex-1 bg-gray-300" />
+        </div>
+        <p className="text-center text-sm">
+          {"Don't have an account?"}{' '}
+          <Link href="/signup" className="underline">
+            Sign up
+          </Link>
+        </p>
+      </div>
     </div>
   );
 }

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { signup } from '@/lib/auth';
 import { Button } from '@/components/ui/button';
@@ -25,35 +26,63 @@ export default function SignupPage() {
   };
 
   return (
-    <div className="flex flex-col items-center justify-center h-[60vh] gap-4">
-      <h1 className="text-2xl font-bold">Sign Up</h1>
-      <form onSubmit={handleSubmit} className="w-full max-w-xs space-y-2">
-        <Input
-          type="email"
-          placeholder="Email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          required
-        />
-        <Input
-          type="text"
-          placeholder="Username"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
-          required
-        />
-        <Input
-          type="password"
-          placeholder="Password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          required
-        />
-        {error && <p className="text-red-500 text-sm">{error}</p>}
-        <Button type="submit" className="w-full">
-          Sign Up
-        </Button>
-      </form>
+    <div className="flex justify-center">
+      <div className="w-full max-w-md py-10 space-y-6">
+        <h1 className="text-2xl font-bold text-center">Create Your Account</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1">
+            <label htmlFor="email" className="block text-sm font-medium">
+              Email
+            </label>
+            <Input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-1">
+            <label htmlFor="username" className="block text-sm font-medium">
+              Username
+            </label>
+            <Input
+              id="username"
+              type="text"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-1">
+            <label htmlFor="password" className="block text-sm font-medium">
+              Password
+            </label>
+            <Input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </div>
+          {error && <p className="text-red-500 text-sm">{error}</p>}
+          <Button type="submit" className="w-full">
+            Sign Up
+          </Button>
+        </form>
+        <div className="flex items-center gap-2 text-sm text-gray-500">
+          <span className="h-px flex-1 bg-gray-300" />
+          OR
+          <span className="h-px flex-1 bg-gray-300" />
+        </div>
+        <p className="text-center text-sm">
+          {"Already have an account?"}{' '}
+          <Link href="/login" className="underline">
+            Login
+          </Link>
+        </p>
+      </div>
     </div>
   );
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,19 +1,55 @@
+"use client";
+
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 import { Button } from './ui/button';
+import { getToken, logout } from '@/lib/auth';
 
 export default function Navbar() {
+  const [loggedIn, setLoggedIn] = useState(false);
+
+  useEffect(() => {
+    setLoggedIn(!!getToken());
+  }, []);
+
+  const handleLogout = () => {
+    logout();
+    setLoggedIn(false);
+  };
+
   return (
-    <nav className="flex items-center justify-between py-4">
+    <nav className="flex items-center justify-between border-b px-4 py-4">
       <Link href="/" className="font-bold text-xl">
         Stylefolks
       </Link>
-      <div className="flex gap-2">
-        <Link href="/login">
-          <Button variant="outline">Login</Button>
+      <div className="flex gap-4 items-center">
+        <Link href="/posts" className="hidden sm:inline-block">
+          Posts
         </Link>
-        <Link href="/signup">
-          <Button>Sign up</Button>
+        <Link href="/crews" className="hidden sm:inline-block">
+          Crews
         </Link>
+        {loggedIn ? (
+          <>
+            <Link href="/profile" className="hidden sm:inline-block">
+              Profile
+            </Link>
+            <Button variant="outline" onClick={handleLogout} className="text-sm">
+              Logout
+            </Button>
+          </>
+        ) : (
+          <>
+            <Link href="/login" className="hidden sm:inline-block">
+              <Button variant="outline" size="sm">
+                Login
+              </Button>
+            </Link>
+            <Link href="/signup">
+              <Button size="sm">Sign up</Button>
+            </Link>
+          </>
+        )}
       </div>
     </nav>
   );

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -11,6 +11,11 @@ export function getToken(): string | null {
   return localStorage.getItem(TOKEN_KEY);
 }
 
+export function logout() {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.removeItem(TOKEN_KEY);
+}
+
 export async function login(email: string, password: string) {
   const res = await fetch(`${API_BASE}/auth/login`, {
     method: 'POST',

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,4 +1,4 @@
-import { setToken, getToken, TOKEN_KEY, login, signup } from '../src/lib/auth';
+import { setToken, getToken, TOKEN_KEY, login, signup, logout } from '../src/lib/auth';
 
 declare global {
   // eslint-disable-next-line no-var
@@ -35,6 +35,12 @@ describe('auth helpers', () => {
   it('returns null when removed', () => {
     localStorage.setItem(TOKEN_KEY, 'xyz');
     localStorage.removeItem(TOKEN_KEY);
+    expect(getToken()).toBeNull();
+  });
+
+  it('logout removes the token', () => {
+    setToken('bye');
+    logout();
     expect(getToken()).toBeNull();
   });
 


### PR DESCRIPTION
## Summary
- add a global `Navbar` to layout
- implement logout helper and test
- update login and signup screens with labelled fields and links
- show login/signup state in navbar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684794ca70f0832097ed0522e77e1fc0