### PR TITLE
Fix hydration mismatch and nav update

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,14 +1,21 @@
 'use client';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { Button } from './ui/button';
 import { getToken, logout } from '@/lib/auth';
 
 export default function Navbar() {
+  const location = useLocation();
   const [loggedIn, setLoggedIn] = useState(false);
 
   useEffect(() => {
     setLoggedIn(!!getToken());
+  }, [location]);
+
+  useEffect(() => {
+    const handler = () => setLoggedIn(!!getToken());
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
   }, []);
 
   const handleLogout = () => {

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -6,12 +6,14 @@ export interface Post {
   content: string;
 }
 
+const BASE_TIME = Date.UTC(2023, 0, 1); // fixed date for deterministic output
+
 export function mockPost(id: number): Post {
   return {
     id,
     title: `Post ${id}`,
     image: `https://picsum.photos/seed/${id}/600/400`,
-    date: new Date(Date.now() - id * 24 * 60 * 60 * 1000).toISOString(),
+    date: new Date(BASE_TIME - id * 24 * 60 * 60 * 1000).toISOString(),
     content: `This is the content for post ${id}.`,
   };
 }


### PR DESCRIPTION
## Summary
- make mocked posts deterministic so SSR and client match
- keep navbar login state in sync with location and storage events

## Testing
- `npm run lint`
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_684f6575a8e08320966b82d2ebf47adc