### PR TITLE
Handle /profile route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,8 @@ import Crews from '@/pages/Crews';
 import Crew from '@/pages/Crew';
 import Brand from '@/pages/Brand';
 import Profile from '@/pages/Profile';
+import MyProfile from '@/pages/MyProfile';
+import RequireAuth from '@/components/RequireAuth';
 import { Routes, Route } from 'react-router-dom';
 import './styles/globals.css';
 
@@ -27,7 +29,10 @@ export default function App() {
           <Route path="/crews" element={<Crews />} />
           <Route path="/crew/:crewId" element={<Crew />} />
           <Route path="/brand/:brandId" element={<Brand />} />
-          <Route path="/profile/:userId" element={<Profile />} />
+          <Route element={<RequireAuth />}> 
+            <Route path="/profile" element={<MyProfile />} />
+            <Route path="/profile/:userId" element={<Profile />} />
+          </Route>
         </Routes>
       </main>
     </>

--- a/src/components/RequireAuth.tsx
+++ b/src/components/RequireAuth.tsx
@@ -1,0 +1,11 @@
+import { Outlet, Navigate, useLocation } from 'react-router-dom';
+import { getToken } from '@/lib/auth';
+
+export default function RequireAuth() {
+  const location = useLocation();
+  const token = getToken();
+  if (!token) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+  return <Outlet />;
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -65,7 +65,20 @@ export async function signup(email: string, username: string, password: string) 
   if (!res.ok) {
     throw new Error('Sign up failed');
   }
-  // automatically log in after successful signup
+  let data: any = {};
+  try {
+    data = await res.json();
+  } catch {
+    // some APIs may return no body
+  }
+  if (data.accessToken) {
+    setToken(data.accessToken);
+    if (data.userId) {
+      setUserId(data.userId);
+    }
+    return;
+  }
+  // automatically log in after successful signup when no token is returned
   await login(email, password);
 }
 

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -49,7 +49,7 @@ export const handlers = [
   }),
 
   http.post(`${API_BASE}/auth/signup`, async () => {
-    return HttpResponse.json({}, { status: 200 });
+    return HttpResponse.json({ accessToken: 'mock-token', userId: currentProfile.userId }, { status: 200 });
   }),
 
   http.get(`${API_BASE}/user/me`, () => {

--- a/src/pages/MyProfile.tsx
+++ b/src/pages/MyProfile.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getMyId } from '@/lib/auth';
+
+export default function MyProfile() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    async function redirect() {
+      try {
+        const id = await getMyId();
+        if (id) {
+          navigate(`/profile/${id}`, { replace: true });
+          return;
+        }
+      } catch {
+        // ignore errors and fall through to login
+      }
+      navigate('/login', { replace: true });
+    }
+    redirect();
+  }, [navigate]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add MyProfile page to redirect to the current user's profile
- protect profile pages behind auth guard
- allow signup API to return a token

## Testing
- `npm test`
- `npx playwright install chromium`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_684f77e8039c83209a8f5f7cef7731c0