### PR TITLE
Add post detail page with ProseMirror and comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "express": "^4.21.2",
+        "prosemirror-model": "^1.25.1",
+        "prosemirror-schema-basic": "^1.2.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -6399,6 +6401,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
+    },
     "node_modules/outvariant": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
@@ -6677,6 +6685,24 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.1.tgz",
+      "integrity": "sha512-AUvbm7qqmpZa5d9fPKMvH1Q5bqYQvAZWOGRvxsB6iFLyycvC9MwNemNVjHVrWgjaoxAfY8XVg7DbvQ/qxvI9Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-basic": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.4.tgz",
+      "integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.25.0"
       }
     },
     "node_modules/proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   "dependencies": {
     "express": "^4.21.2",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "prosemirror-model": "^1.25.1",
+    "prosemirror-schema-basic": "^1.2.4"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ export default function App() {
           <Route path="/signup" element={<Signup />} />
           <Route path="/posts" element={<Posts />} />
           <Route path="/posts/:id" element={<Post />} />
+          <Route path="/post/:postId" element={<Post />} />
           <Route path="/crews" element={<Crews />} />
           <Route path="/crew/:crewId" element={<Crew />} />
           <Route path="/brand/:brandId" element={<Brand />} />

--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import { Input } from './ui/input';
+import { Button } from './ui/button';
+
+interface Comment {
+  id: number;
+  text: string;
+}
+
+export default function Comments({ postId }: { postId: string }) {
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [text, setText] = useState('');
+
+  useEffect(() => {
+    const stored = localStorage.getItem(`comments-${postId}`);
+    if (stored) {
+      try {
+        setComments(JSON.parse(stored));
+      } catch {
+        setComments([]);
+      }
+    }
+  }, [postId]);
+
+  const addComment = () => {
+    if (!text.trim()) return;
+    const newComment = { id: Date.now(), text };
+    const updated = [...comments, newComment];
+    setComments(updated);
+    localStorage.setItem(`comments-${postId}`, JSON.stringify(updated));
+    setText('');
+  };
+
+  return (
+    <div className="mt-6 space-y-3">
+      <h2 className="font-semibold">Comments</h2>
+      {comments.length === 0 ? (
+        <p className="text-sm text-gray-500">No comments yet.</p>
+      ) : (
+        <ul className="space-y-2">
+          {comments.map((c) => (
+            <li key={c.id} className="rounded border p-2">
+              {c.text}
+            </li>
+          ))}
+        </ul>
+      )}
+      <div className="flex space-x-2 pt-2">
+        <Input
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="Add a comment"
+        />
+        <Button type="button" onClick={addComment} className="shrink-0">
+          Post
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/PostGrid.tsx
+++ b/src/components/PostGrid.tsx
@@ -22,7 +22,7 @@ export default function PostGrid() {
 
   const handlePostClick = (id: string) => {
     document.startViewTransition(() => {
-      navigate(`/posts/${id}`);
+      navigate(`/post/${id}`);
     });
   };
 

--- a/src/components/ProseMirrorRenderer.tsx
+++ b/src/components/ProseMirrorRenderer.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from 'react';
+import { DOMSerializer } from 'prosemirror-model';
+import { schema } from 'prosemirror-schema-basic';
+
+interface Props {
+  content: any;
+}
+
+export default function ProseMirrorRenderer({ content }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    try {
+      const node = schema.nodeFromJSON(content);
+      const fragment = DOMSerializer.fromSchema(schema).serializeFragment(
+        node.content,
+      );
+      const container = ref.current;
+      container.innerHTML = '';
+      container.appendChild(fragment);
+    } catch {
+      ref.current.textContent = 'Invalid content';
+    }
+  }, [content]);
+
+  return <div ref={ref} />;
+}

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -3,7 +3,7 @@ export interface Post {
   title: string;
   image: string;
   date: string;
-  content: string;
+  content: any; // ProseMirror JSON
 }
 
 const BASE_TIME = Date.UTC(2023, 0, 1); // fixed date for deterministic output
@@ -14,7 +14,17 @@ export function mockPost(id: number): Post {
     title: `Post ${id}`,
     image: `https://picsum.photos/seed/${id}/600/400`,
     date: new Date(BASE_TIME - id * 24 * 60 * 60 * 1000).toISOString(),
-    content: `This is the content for post ${id}.`,
+    content: {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: `This is the content for post ${id}.` },
+          ],
+        },
+      ],
+    },
   };
 }
 

--- a/src/pages/Post.tsx
+++ b/src/pages/Post.tsx
@@ -1,16 +1,18 @@
 import { useParams, useNavigate } from 'react-router-dom';
 import { getPostById, getNextPosts } from '@/lib/posts';
+import ProseMirrorRenderer from '@/components/ProseMirrorRenderer';
+import Comments from '@/components/Comments';
 
 export default function PostPage() {
   const navigate = useNavigate();
   const params = useParams();
-  const id = Number(params.id);
+  const id = Number(params.postId ?? params.id);
   const post = getPostById(id);
   const nextPosts = getNextPosts(id, 3);
 
   const go = (postId: number) => {
     document.startViewTransition(() => {
-      navigate(`/posts/${postId}`);
+      navigate(`/post/${postId}`);
     });
   };
 
@@ -25,7 +27,8 @@ export default function PostPage() {
         <div style={{ viewTransitionName: `post-${post.id}` }}>
           <img src={post.image} alt={post.title} className="my-4 w-full rounded-md" />
         </div>
-        <p>{post.content}</p>
+        <ProseMirrorRenderer content={post.content} />
+        <Comments postId={String(id)} />
       </article>
       <aside className="ml-8 hidden w-64 space-y-4 md:block">
         {nextPosts.map((p) => (

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -257,7 +257,7 @@ export default function ProfilePage() {
             <ul className="list-disc pl-5">
               {posts.map((p) => (
                 <li key={p.id}>
-                  <Link to={`/posts/${p.id}`}>{p.title}</Link>
+                  <Link to={`/post/${p.id}`}>{p.title}</Link>
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
## Summary
- render posts using ProseMirror JSON
- add simple comment system stored in localStorage
- update routes and navigation to `/post/:postId`
- include ProseMirror renderer and comments components
- update mock post content

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fa01005348320aa3cb28ade1d9dba