### PR TITLE
Add Write page using ProseMirror

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,16 @@
       "version": "0.1.0",
       "dependencies": {
         "express": "^4.21.2",
+        "prosemirror-commands": "^1.7.1",
+        "prosemirror-dropcursor": "^1.8.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-inputrules": "^1.1.4",
+        "prosemirror-keymap": "^1.2.0",
         "prosemirror-model": "^1.25.1",
         "prosemirror-schema-basic": "^1.2.4",
+        "prosemirror-schema-list": "^1.5.1",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-view": "^1.40.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -6687,6 +6695,60 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-dropcursor": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
+      "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.4.1.tgz",
+      "integrity": "sha512-2JZD8z2JviJrboD9cPuX/Sv/1ChFng+xh2tChQ2X4bB2HeK+rra/bmJ3xGntCcjhOqIzSDG6Id7e8RJ9QPXLEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-inputrules": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.0.tgz",
+      "integrity": "sha512-K0xJRCmt+uSw7xesnHmcn72yBGTbY45vm8gXI4LZXbx2Z0jwh5aF9xrGQgrVPu0WbyFVFF3E/o9VhJYz6SQWnA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
     "node_modules/prosemirror-model": {
       "version": "1.25.1",
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.1.tgz",
@@ -6703,6 +6765,48 @@
       "license": "MIT",
       "dependencies": {
         "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.3.tgz",
+      "integrity": "sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.10.4.tgz",
+      "integrity": "sha512-pwDy22nAnGqNR1feOQKHxoFkkUtepoFAd3r2hbEDsnf4wp57kKA36hXsB3njA9FtONBEwSDnDeCiJe+ItD+ykw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.40.0.tgz",
+      "integrity": "sha512-2G3svX0Cr1sJjkD/DYWSe3cfV5VPVTBOxI9XQEGWJDFEpsZb/gh4MV29ctv+OJx2RFX4BLt09i+6zaGM/ldkCw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -7019,6 +7123,12 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
       "license": "MIT"
     },
     "node_modules/run-parallel": {
@@ -8363,6 +8473,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,15 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "prosemirror-model": "^1.25.1",
-    "prosemirror-schema-basic": "^1.2.4"
+    "prosemirror-schema-basic": "^1.2.4",
+    "prosemirror-state": "^1.4.3",
+    "prosemirror-view": "^1.40.0",
+    "prosemirror-commands": "^1.7.1",
+    "prosemirror-history": "^1.4.1",
+    "prosemirror-keymap": "^1.2.0",
+    "prosemirror-dropcursor": "^1.8.2",
+    "prosemirror-schema-list": "^1.5.1",
+    "prosemirror-inputrules": "^1.1.4"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import Crew from '@/pages/Crew';
 import Brand from '@/pages/Brand';
 import Profile from '@/pages/Profile';
 import MyProfile from '@/pages/MyProfile';
+import Write from '@/pages/Write';
 import RequireAuth from '@/components/RequireAuth';
 import { Routes, Route } from 'react-router-dom';
 import './styles/globals.css';
@@ -30,9 +31,10 @@ export default function App() {
           <Route path="/crews" element={<Crews />} />
           <Route path="/crew/:crewId" element={<Crew />} />
           <Route path="/brand/:brandId" element={<Brand />} />
-          <Route element={<RequireAuth />}> 
+          <Route element={<RequireAuth />}>
             <Route path="/profile" element={<MyProfile />} />
             <Route path="/profile/:userId" element={<Profile />} />
+            <Route path="/write" element={<Write />} />
           </Route>
         </Routes>
       </main>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -40,6 +40,9 @@ export default function Navbar() {
             <Link to="/profile" className="hidden sm:inline-block">
               Profile
             </Link>
+            <Link to="/write" className="hidden sm:inline-block">
+              Write
+            </Link>
             <Button variant="outline" onClick={handleLogout} className="text-sm">
               Logout
             </Button>

--- a/src/components/WriteEditor.tsx
+++ b/src/components/WriteEditor.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useRef } from 'react';
+import { EditorState } from 'prosemirror-state';
+import { EditorView } from 'prosemirror-view';
+import { editorSchema } from '@/lib/editorSchema';
+import { keymap } from 'prosemirror-keymap';
+import { baseKeymap, toggleMark } from 'prosemirror-commands';
+import { history } from 'prosemirror-history';
+import { dropCursor } from 'prosemirror-dropcursor';
+
+interface Props {
+  content: any;
+  onChange: (content: any) => void;
+}
+
+export default function WriteEditor({ content, onChange }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<EditorView | null>(null);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const state = EditorState.create({
+      schema: editorSchema,
+      doc: content ? editorSchema.nodeFromJSON(content) : undefined,
+      plugins: [
+        history(),
+        dropCursor(),
+        keymap({
+          Tab: increaseIndent,
+          'Shift-Tab': decreaseIndent,
+        }),
+        keymap(baseKeymap),
+      ],
+    });
+
+    const view = new EditorView(ref.current, {
+      state,
+      dispatchTransaction(tr) {
+        const newState = view.state.apply(tr);
+        view.updateState(newState);
+        onChange(newState.doc.toJSON());
+      },
+    });
+    viewRef.current = view;
+    return () => {
+      view.destroy();
+    };
+  }, []);
+
+  const applyColor = (color: string) => {
+    if (!viewRef.current) return;
+    toggleMark(editorSchema.marks.color, { color })(viewRef.current.state, viewRef.current.dispatch);
+    viewRef.current.focus();
+  };
+
+  const applyFont = (font: string) => {
+    if (!viewRef.current) return;
+    toggleMark(editorSchema.marks.font, { name: font })(viewRef.current.state, viewRef.current.dispatch);
+    viewRef.current.focus();
+  };
+
+  return (
+    <div>
+      <div className="mb-2 flex gap-2">
+        <input
+          type="color"
+          onChange={(e) => applyColor(e.target.value)}
+          title="Text Color"
+        />
+        <select onChange={(e) => applyFont(e.target.value)} defaultValue="">
+          <option value="" disabled>
+            Font
+          </option>
+          <option value="Arial">Arial</option>
+          <option value="serif">Serif</option>
+          <option value="monospace">Monospace</option>
+        </select>
+        <button
+          type="button"
+          onClick={() => increaseIndent(viewRef.current!.state, viewRef.current!.dispatch)}
+          className="border px-2"
+        >
+          Indent
+        </button>
+        <button
+          type="button"
+          onClick={() => decreaseIndent(viewRef.current!.state, viewRef.current!.dispatch)}
+          className="border px-2"
+        >
+          Outdent
+        </button>
+        <input
+          type="file"
+          accept="image/*"
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (!file || !viewRef.current) return;
+            const reader = new FileReader();
+            reader.onload = () => {
+              const { state, dispatch } = viewRef.current!;
+              const node = editorSchema.nodes.image.create({ src: reader.result });
+              const tr = state.tr.replaceSelectionWith(node);
+              dispatch(tr);
+            };
+            reader.readAsDataURL(file);
+          }}
+        />
+      </div>
+      <div ref={ref} className="min-h-[300px] border p-2" />
+    </div>
+  );
+}
+
+function updateIndent(state: EditorState, dispatch: any, diff: number) {
+  const { from, to } = state.selection;
+  let tr = state.tr;
+  state.doc.nodesBetween(from, to, (node, pos) => {
+    if (node.type === editorSchema.nodes.paragraph) {
+      const indent = Math.max(0, (node.attrs.indent || 0) + diff);
+      tr = tr.setNodeMarkup(pos, undefined, { ...node.attrs, indent });
+    }
+  });
+  if (tr.docChanged) {
+    dispatch(tr);
+    return true;
+  }
+  return false;
+}
+
+function increaseIndent(state: EditorState, dispatch: any) {
+  return updateIndent(state, dispatch, 1);
+}
+
+function decreaseIndent(state: EditorState, dispatch: any) {
+  return updateIndent(state, dispatch, -1);
+}

--- a/src/lib/editorSchema.ts
+++ b/src/lib/editorSchema.ts
@@ -1,0 +1,48 @@
+import { Schema } from 'prosemirror-model';
+import { schema as basic } from 'prosemirror-schema-basic';
+import { schema as list } from 'prosemirror-schema-list';
+
+const nodes = basic.spec.nodes.update('paragraph', {
+  ...basic.spec.nodes.get('paragraph')!,
+  attrs: { indent: { default: 0 } },
+  toDOM(node) {
+    const { indent } = node.attrs as any;
+    const attrs: any = {};
+    if (indent) attrs.style = `margin-left: ${indent * 2}em`;
+    return ['p', attrs, 0];
+  },
+  parseDOM: [{
+    tag: 'p',
+    getAttrs(dom: HTMLElement) {
+      const ml = dom.style.marginLeft;
+      return { indent: ml ? parseInt(ml) / 2 : 0 };
+    },
+  }],
+});
+
+const colorMark = {
+  attrs: { color: {} },
+  parseDOM: [{
+    style: 'color',
+    getAttrs: (value: string) => ({ color: value }),
+  }],
+  toDOM: (mark: any) => ['span', { style: `color:${mark.attrs.color}` }, 0],
+};
+
+const fontMark = {
+  attrs: { name: {} },
+  parseDOM: [{
+    style: 'font-family',
+    getAttrs: (value: string) => ({ name: value }),
+  }],
+  toDOM: (mark: any) => [
+    'span',
+    { style: `font-family:${mark.attrs.name}` },
+    0,
+  ],
+};
+
+export const editorSchema = new Schema({
+  nodes: nodes.append(list.spec.nodes),
+  marks: basic.spec.marks.addToEnd('color', colorMark).addToEnd('font', fontMark),
+});

--- a/src/pages/Write.tsx
+++ b/src/pages/Write.tsx
@@ -1,0 +1,76 @@
+import { useState, useEffect } from 'react';
+import WriteEditor from '@/components/WriteEditor';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+interface Draft {
+  title: string;
+  bigCategory: string;
+  hashtags: string;
+  content: any;
+}
+
+const DRAFT_KEY = 'write_draft';
+
+export default function WritePage() {
+  const [title, setTitle] = useState('');
+  const [bigCategory, setBigCategory] = useState('OOTD');
+  const [hashtags, setHashtags] = useState('');
+  const [content, setContent] = useState<any>(null);
+
+  useEffect(() => {
+    const raw = localStorage.getItem(DRAFT_KEY);
+    if (raw) {
+      const draft: Draft = JSON.parse(raw);
+      setTitle(draft.title);
+      setBigCategory(draft.bigCategory);
+      setHashtags(draft.hashtags);
+      setContent(draft.content);
+    }
+  }, []);
+
+  const saveDraft = () => {
+    const draft: Draft = { title, bigCategory, hashtags, content };
+    localStorage.setItem(DRAFT_KEY, JSON.stringify(draft));
+    alert('Draft saved');
+  };
+
+  const clearDraft = () => {
+    localStorage.removeItem(DRAFT_KEY);
+    alert('Draft cleared');
+  };
+
+  return (
+    <div className="mx-auto max-w-2xl p-4 space-y-4">
+      <h1 className="text-xl font-bold">Write a Post</h1>
+      <Input
+        placeholder="Title"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+      />
+      <select
+        value={bigCategory}
+        onChange={(e) => setBigCategory(e.target.value)}
+        className="w-full border p-2 rounded"
+      >
+        <option value="OOTD">OOTD</option>
+        <option value="Column">Column</option>
+        <option value="Review">Review</option>
+      </select>
+      <Input
+        placeholder="Hashtags (comma separated)"
+        value={hashtags}
+        onChange={(e) => setHashtags(e.target.value)}
+      />
+      <WriteEditor content={content} onChange={setContent} />
+      <div className="flex gap-2">
+        <Button type="button" onClick={saveDraft} variant="outline">
+          Save Draft
+        </Button>
+        <Button type="button" onClick={clearDraft} variant="outline">
+          Clear Draft
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add ProseMirror editing schema for colors, fonts and indent
- implement WriteEditor with basic toolbar (color, font, indent, image upload)
- create Write page with draft save/load support
- link Write page in navbar and routes
- include ProseMirror dependencies

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e` *(fails: browser binaries missing)*

------
https://chatgpt.com/codex/tasks/task_e_684fbf9e675483209e40bf3c8c9f528d