### PR TITLE
Add formatting buttons to editor

### DIFF
--- a/src/components/ProseMirrorRenderer.tsx
+++ b/src/components/ProseMirrorRenderer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { DOMSerializer } from 'prosemirror-model';
-import { schema } from 'prosemirror-schema-basic';
+import { editorSchema } from '@/lib/editorSchema';
 
 interface Props {
   content: any;
@@ -12,8 +12,8 @@ export default function ProseMirrorRenderer({ content }: Props) {
   useEffect(() => {
     if (!ref.current) return;
     try {
-      const node = schema.nodeFromJSON(content);
-      const fragment = DOMSerializer.fromSchema(schema).serializeFragment(
+      const node = editorSchema.nodeFromJSON(content);
+      const fragment = DOMSerializer.fromSchema(editorSchema).serializeFragment(
         node.content,
       );
       const container = ref.current;

--- a/src/components/WriteEditor.tsx
+++ b/src/components/WriteEditor.tsx
@@ -4,6 +4,7 @@ import { EditorView } from 'prosemirror-view';
 import { editorSchema } from '@/lib/editorSchema';
 import { keymap } from 'prosemirror-keymap';
 import { baseKeymap, toggleMark } from 'prosemirror-commands';
+import { wrapInList } from 'prosemirror-schema-list';
 import { history } from 'prosemirror-history';
 import { dropCursor } from 'prosemirror-dropcursor';
 
@@ -58,6 +59,18 @@ export default function WriteEditor({ content, onChange }: Props) {
     viewRef.current.focus();
   };
 
+  const toggle = (mark: any) => {
+    if (!viewRef.current) return;
+    toggleMark(mark)(viewRef.current.state, viewRef.current.dispatch);
+    viewRef.current.focus();
+  };
+
+  const wrapList = (listType: any) => {
+    if (!viewRef.current) return;
+    wrapInList(listType)(viewRef.current.state, viewRef.current.dispatch);
+    viewRef.current.focus();
+  };
+
   return (
     <div>
       <div className="mb-2 flex gap-2 flex-wrap">
@@ -74,6 +87,24 @@ export default function WriteEditor({ content, onChange }: Props) {
           <option value="serif">Serif</option>
           <option value="monospace">Monospace</option>
         </select>
+        <button type="button" onClick={() => toggle(editorSchema.marks.strong)} className="border px-2">
+          Bold
+        </button>
+        <button type="button" onClick={() => toggle(editorSchema.marks.em)} className="border px-2">
+          Italic
+        </button>
+        <button type="button" onClick={() => toggle(editorSchema.marks.underline)} className="border px-2">
+          Underline
+        </button>
+        <button type="button" onClick={() => toggle(editorSchema.marks.strike)} className="border px-2">
+          Strike
+        </button>
+        <button type="button" onClick={() => wrapList(editorSchema.nodes.bullet_list)} className="border px-2">
+          Bullets
+        </button>
+        <button type="button" onClick={() => wrapList(editorSchema.nodes.ordered_list)} className="border px-2">
+          Numbered
+        </button>
         <button
           type="button"
           onClick={() => increaseIndent(viewRef.current!.state, viewRef.current!.dispatch)}

--- a/src/lib/editorSchema.ts
+++ b/src/lib/editorSchema.ts
@@ -37,10 +37,12 @@ const colorMark: MarkSpec = {
 
 const fontMark: MarkSpec = {
   attrs: { name: {} },
-  parseDOM: [{
-    style: 'font-family',
-    getAttrs: (value: string) => ({ name: value }),
-  }],
+  parseDOM: [
+    {
+      style: 'font-family',
+      getAttrs: (value: string) => ({ name: value }),
+    },
+  ],
   toDOM: (mark: any) => [
     'span',
     { style: `font-family:${mark.attrs.name}` },
@@ -48,7 +50,27 @@ const fontMark: MarkSpec = {
   ],
 };
 
+const underlineMark: MarkSpec = {
+  parseDOM: [
+    { tag: 'u' },
+    { style: 'text-decoration=underline' },
+  ],
+  toDOM: () => ['span', { style: 'text-decoration:underline' }, 0],
+};
+
+const strikeMark: MarkSpec = {
+  parseDOM: [
+    { tag: 's' },
+    { style: 'text-decoration=line-through' },
+  ],
+  toDOM: () => ['span', { style: 'text-decoration:line-through' }, 0],
+};
+
 export const editorSchema = new Schema({
   nodes,
-  marks: basic.spec.marks.addToEnd('color', colorMark).addToEnd('font', fontMark),
+  marks: basic.spec.marks
+    .addToEnd('color', colorMark)
+    .addToEnd('font', fontMark)
+    .addToEnd('underline', underlineMark)
+    .addToEnd('strike', strikeMark),
 });


### PR DESCRIPTION
## Summary
- upgrade editor schema with underline and strike marks
- use the custom schema when rendering posts
- add bold, italic, underline, strike, and list controls to the write editor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fdbc9f45c8320b0c0e1b74eb922ac