### PR TITLE
Add image upload placeholder to ProseMirror editor

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -37,3 +37,18 @@ body {
   color: var(--foreground);
   font-family: var(--font-sans), Arial, Helvetica, sans-serif;
 }
+
+placeholder {
+  display: inline;
+  border: 1px solid #ccc;
+  color: #ccc;
+}
+placeholder:after {
+  content: "\2601";
+  font-size: 200%;
+  line-height: 0.1;
+  font-weight: bold;
+}
+.ProseMirror img {
+  max-width: 100px;
+}


### PR DESCRIPTION
## Summary
- update ProseMirror editor with placeholder upload plugin
- style placeholders and uploaded images

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850b31dc2e48320bdae16564002cd25