### PR TITLE
Add post viewer and mock API

### DIFF
--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -1,19 +1,41 @@
-import { editorSchema } from '@/lib/editorSchema';
+import React, { useEffect, useRef } from 'react';
+import OrderedMap from 'orderedmap';
+import { Node, NodeSpec, Schema } from 'prosemirror-model';
+import { EditorState } from 'prosemirror-state';
+import { EditorView } from 'prosemirror-view';
+import { schema as baseSchema } from 'prosemirror-schema-basic';
+import { addListNodes } from 'prosemirror-schema-list';
+import './Editor/core/editor.css';
 import { setup } from './Editor/core';
-import useProseMirror from '@/hooks/useProseMirror';
-import '@/styles/editor.css';
 
 interface Props {
   content: any;
 }
 
 export default function Viewer({ content }: Props) {
-  const ref = useProseMirror({
-    schema: editorSchema,
-    doc: content,
-    plugins: setup({ schema: editorSchema, menuBar: false, history: false }),
-    editable: false,
-  });
+  const ref = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<EditorView | null>(null);
 
-  return <div ref={ref} className="min-h-[300px] border p-2" />;
+  const baseNodes: OrderedMap<NodeSpec> | NodeSpec = addListNodes(
+    baseSchema.spec.nodes,
+    'paragraph block*',
+    'block',
+  );
+  const nodes = baseNodes.append([]);
+  const marks = baseSchema.spec.marks;
+  const schema = new Schema({ nodes, marks });
+  const doc = Node.fromJSON(schema, content);
+  const plugins = setup({ schema, menuBar: false, history: false });
+  const state = EditorState.create({ doc, plugins });
+
+  useEffect(() => {
+    if (ref.current && !viewRef.current) {
+      viewRef.current = new EditorView(ref.current, {
+        state,
+        editable: () => false,
+      });
+    }
+  }, [state]);
+
+  return <div ref={ref} className="editor-wrapper" />;
 }

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,3 +1,5 @@
+import { API_BASE } from './auth';
+
 export interface Post {
   id: number;
   title: string;
@@ -39,4 +41,12 @@ export function getPostById(id: number): Post {
 
 export function getNextPosts(startId: number, limit: number): Post[] {
   return Array.from({ length: limit }, (_, i) => mockPost(startId + i + 1));
+}
+
+export async function fetchPost(id: number): Promise<Post> {
+  const res = await fetch(`${API_BASE}/posts/${id}`, { cache: 'no-store' });
+  if (!res.ok) {
+    throw new Error('Failed to load post');
+  }
+  return res.json();
 }

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -78,4 +78,33 @@ export const handlers = [
     const { id } = params as { id: string };
     return HttpResponse.json(randomProfile(id));
   }),
+
+  http.get(`${API_BASE}/posts/:id`, ({ params }) => {
+    const { id } = params as { id: string };
+    const seed = Math.random().toString(36).slice(2, 8);
+    const content = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: `Random post ${id}` },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: `Generated ${seed}` },
+          ],
+        },
+      ],
+    };
+    return HttpResponse.json({
+      id: Number(id),
+      title: `Random Post ${id}`,
+      image: `https://picsum.photos/seed/${seed}/600/400`,
+      date: new Date().toISOString(),
+      content,
+    });
+  }),
 ];

--- a/src/pages/Post.tsx
+++ b/src/pages/Post.tsx
@@ -1,20 +1,33 @@
 import { useParams, useNavigate } from 'react-router-dom';
-import { getPostById, getNextPosts } from '@/lib/posts';
+import { getNextPosts, fetchPost, type Post } from '@/lib/posts';
 import Viewer from '@/components/Viewer';
 import Comments from '@/components/Comments';
+import { useEffect, useState } from 'react';
 
 export default function PostPage() {
   const navigate = useNavigate();
   const params = useParams();
   const id = Number(params.postId ?? params.id);
-  const post = getPostById(id);
+  const [post, setPost] = useState<Post | null>(null);
+  const [loading, setLoading] = useState(true);
   const nextPosts = getNextPosts(id, 3);
+
+  useEffect(() => {
+    setLoading(true);
+    fetchPost(id)
+      .then((p) => setPost(p))
+      .catch(() => setPost(null))
+      .finally(() => setLoading(false));
+  }, [id]);
 
   const go = (postId: number) => {
     document.startViewTransition(() => {
       navigate(`/post/${postId}`);
     });
   };
+
+  if (loading) return <p className="p-4">Loading...</p>;
+  if (!post) return <p className="p-4">No post</p>;
 
   return (
     <div className="mx-auto flex max-w-5xl p-4">


### PR DESCRIPTION
## Summary
- implement read-only Viewer using editor setup
- fetch posts by id from mock API in Post page
- provide fetchPost helper for posts
- extend MSW handlers to serve random post content

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685209f32e688320b9889a0b86f5471d