### PR TITLE
Implement rich ProseMirror viewer

### DIFF
--- a/src/components/Editor/index.tsx
+++ b/src/components/Editor/index.tsx
@@ -1,12 +1,8 @@
 import React, { useEffect, useRef } from "react";
-import OrderedMap from "orderedmap";
-
-import { Node, NodeSpec } from "prosemirror-model";
+import { Node } from "prosemirror-model";
 import { EditorState } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
-import { Schema } from "prosemirror-model";
-import { schema as baseSchema } from "prosemirror-schema-basic";
-import { addListNodes } from "prosemirror-schema-list";
+import { editorSchema } from "@/lib/editorSchema";
 import "../Editor/core/editor.css"
 import { setup } from "./core";
 
@@ -18,14 +14,7 @@ interface EditorProps {
 export const Editor: React.FC<EditorProps> = React.memo(({ value , onChange}: EditorProps) => {
   const ref = useRef<HTMLDivElement>(null);
   const editorRef = useRef<EditorView>(null!);
-  const baseNodes: OrderedMap<NodeSpec> | NodeSpec = addListNodes(
-    baseSchema.spec.nodes,
-    "paragraph block*",
-    "block"
-  );
-  const nodes = baseNodes.append([]);
-  const marks = baseSchema.spec.marks;
-  const schema = new Schema({ nodes, marks });
+  const schema = editorSchema;
   const doc = Node.fromJSON(schema, value);
   const plugins = setup({ schema });
   const state = EditorState.create({ doc, plugins });

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -1,10 +1,8 @@
 import React, { useEffect, useRef } from 'react';
-import OrderedMap from 'orderedmap';
-import { Node, NodeSpec, Schema } from 'prosemirror-model';
+import { Node } from 'prosemirror-model';
 import { EditorState } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
-import { schema as baseSchema } from 'prosemirror-schema-basic';
-import { addListNodes } from 'prosemirror-schema-list';
+import { editorSchema } from '@/lib/editorSchema';
 import './Editor/core/editor.css';
 import { setup } from './Editor/core';
 
@@ -16,14 +14,7 @@ export default function Viewer({ content }: Props) {
   const ref = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
 
-  const baseNodes: OrderedMap<NodeSpec> | NodeSpec = addListNodes(
-    baseSchema.spec.nodes,
-    'paragraph block*',
-    'block',
-  );
-  const nodes = baseNodes.append([]);
-  const marks = baseSchema.spec.marks;
-  const schema = new Schema({ nodes, marks });
+  const schema = editorSchema;
   const doc = Node.fromJSON(schema, content);
   const plugins = setup({ schema, menuBar: false, history: false });
   const state = EditorState.create({ doc, plugins });

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -94,7 +94,34 @@ export const handlers = [
         {
           type: 'paragraph',
           content: [
-            { type: 'text', text: `Generated ${seed}` },
+            {
+              type: 'text',
+              text: '다양한 스타일의 문단 ' ,
+              marks: [
+                { type: 'font', attrs: { name: 'Georgia' } },
+                { type: 'color', attrs: { color: 'blue' } },
+              ],
+            },
+            { type: 'text', text: '😊' },
+          ],
+        },
+        {
+          type: 'image',
+          attrs: {
+            src: `https://picsum.photos/seed/${seed}/400/300`,
+            alt: 'random image',
+          },
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Comic Sans 폰트의 문단입니다.',
+              marks: [
+                { type: 'font', attrs: { name: 'Comic Sans MS' } },
+              ],
+            },
           ],
         },
       ],


### PR DESCRIPTION
## Summary
- use shared custom schema in Editor and Viewer
- update mock post content with custom marks and images

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68525fdfa71c8320b8301e5ab75d4113