### PR TITLE
Add settings page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import Crew from '@/pages/Crew';
 import Brand from '@/pages/Brand';
 import Profile from '@/pages/Profile';
 import MyProfile from '@/pages/MyProfile';
+import SettingsPage from '@/pages/Settings';
 import Write from '@/pages/Write';
 import RequireAuth from '@/components/RequireAuth';
 import { Routes, Route } from 'react-router-dom';
@@ -32,6 +33,7 @@ export default function App() {
           <Route element={<RequireAuth />}>
             <Route path="/profile" element={<MyProfile />} />
             <Route path="/profile/:userId" element={<Profile />} />
+            <Route path="/settings" element={<SettingsPage />} />
           </Route>
           <Route path="/write" element={<Write />} />
         </Routes>

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -1,0 +1,65 @@
+'use client';
+import { Link } from 'react-router-dom';
+import { Button } from './ui/button';
+import { cn } from '@/lib/utils';
+
+interface MobileNavProps {
+  open: boolean;
+  onClose: () => void;
+  loggedIn: boolean;
+}
+
+export default function MobileNav({ open, onClose, loggedIn }: MobileNavProps) {
+  return (
+    <div
+      className={cn(
+        'fixed inset-0 z-50 flex flex-col sm:hidden transition-opacity duration-300',
+        open ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
+      )}
+      onClick={onClose}
+    >
+      <div className="flex-1" />
+      <div
+        className={cn(
+          'bg-background p-4 shadow-md transition-transform duration-300',
+          open ? 'translate-y-0' : 'translate-y-full'
+        )}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <nav className="flex flex-col gap-4">
+          <Link to="/posts" onClick={onClose} className="py-2">
+            Posts
+          </Link>
+          <Link to="/crews" onClick={onClose} className="py-2">
+            Crews
+          </Link>
+          <Link to="/write" onClick={onClose} className="py-2">
+            Write
+          </Link>
+          {loggedIn ? (
+            <>
+              <Link to="/profile" onClick={onClose} className="py-2">
+                Profile
+              </Link>
+              <Link to="/settings" onClick={onClose} className="py-2">
+                Settings
+              </Link>
+            </>
+          ) : (
+            <>
+              <Link to="/login" onClick={onClose} className="py-2">
+                <Button variant="outline" size="sm" className="w-full">
+                  Login
+                </Button>
+              </Link>
+              <Link to="/signup" onClick={onClose} className="py-2">
+                <Button size="sm" className="w-full">Sign up</Button>
+              </Link>
+            </>
+          )}
+        </nav>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -2,11 +2,13 @@
 import { Link, useLocation } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { Button } from './ui/button';
-import { getToken, logout } from '@/lib/auth';
+import MobileNav from './MobileNav';
+import { getToken } from '@/lib/auth';
 
 export default function Navbar() {
   const location = useLocation();
   const [loggedIn, setLoggedIn] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
 
   useEffect(() => {
     setLoggedIn(!!getToken());
@@ -18,10 +20,6 @@ export default function Navbar() {
     return () => window.removeEventListener('storage', handler);
   }, []);
 
-  const handleLogout = () => {
-    logout();
-    setLoggedIn(false);
-  };
 
   return (
     <nav className="flex items-center justify-between border-b px-4 py-4">
@@ -29,6 +27,13 @@ export default function Navbar() {
         Stylefolks
       </Link>
       <div className="flex gap-4 items-center">
+        <button
+          className="sm:hidden p-2"
+          onClick={() => setMobileOpen(true)}
+          aria-label="Open menu"
+        >
+          &#9776;
+        </button>
         <Link to="/posts" className="hidden sm:inline-block">
           Posts
         </Link>
@@ -43,9 +48,9 @@ export default function Navbar() {
             <Link to="/profile" className="hidden sm:inline-block">
               Profile
             </Link>
-            <Button variant="outline" onClick={handleLogout} className="text-sm">
-              Logout
-            </Button>
+            <Link to="/settings" className="hidden sm:inline-block">
+              Settings
+            </Link>
           </>
         ) : (
           <>
@@ -61,5 +66,11 @@ export default function Navbar() {
         )}
       </div>
     </nav>
+    <MobileNav
+      open={mobileOpen}
+      onClose={() => setMobileOpen(false)}
+      loggedIn={loggedIn}
+    />
   );
 }
+

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,20 @@
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { logout } from '@/lib/auth';
+
+export default function SettingsPage() {
+  const navigate = useNavigate();
+  const handleLogout = () => {
+    logout();
+    navigate('/login');
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Settings</h1>
+      <Button onClick={handleLogout} variant="outline">
+        Logout
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- allow access to a new `Settings` page for logged-in users
- move logout to settings page
- tweak navigation items for desktop and mobile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68535587d8d88320b22c557bc0404909