### PR TITLE
Update post page layout

### DIFF
--- a/src/components/Editor/core/editor.css
+++ b/src/components/Editor/core/editor.css
@@ -1,5 +1,5 @@
 .editor-wrapper {
-  max-width: 760px;
+  max-width: 100%;
   min-height: 240px;
   margin: 0 auto;
   padding-bottom: 12px;

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -3,14 +3,16 @@ import { Node } from 'prosemirror-model';
 import { EditorState } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 import { editorSchema } from '@/lib/editorSchema';
+import { cn } from '@/lib/utils';
 import './Editor/core/editor.css';
 import { setup } from './Editor/core';
 
 interface Props {
   content: any;
+  className?: string;
 }
 
-export default function Viewer({ content }: Props) {
+export default function Viewer({ content, className }: Props) {
   const ref = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
 
@@ -28,5 +30,5 @@ export default function Viewer({ content }: Props) {
     }
   }, [state]);
 
-  return <div ref={ref} className="editor-wrapper" />;
+  return <div ref={ref} className={cn('editor-wrapper', className)} />;
 }

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,21 +1,31 @@
 import { API_BASE } from './auth';
+import type { SimpleUser } from './profile';
 
 export interface Post {
   id: number;
   title: string;
   image: string;
   date: string;
+  views: number;
+  author: SimpleUser;
   content: any; // ProseMirror JSON
 }
 
 const BASE_TIME = Date.UTC(2023, 0, 1); // fixed date for deterministic output
 
 export function mockPost(id: number): Post {
+  const author: SimpleUser = {
+    userId: `user${id}`,
+    username: `User ${id}`,
+    imageUrl: `https://picsum.photos/seed/user${id}/100`,
+  };
   return {
     id,
     title: `Post ${id}`,
     image: `https://picsum.photos/seed/${id}/600/400`,
     date: new Date(BASE_TIME - id * 24 * 60 * 60 * 1000).toISOString(),
+    views: id * 10,
+    author,
     content: {
       type: 'doc',
       content: [

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -82,6 +82,7 @@ export const handlers = [
   http.get(`${API_BASE}/posts/:id`, ({ params }) => {
     const { id } = params as { id: string };
     const seed = Math.random().toString(36).slice(2, 8);
+    const author = randomProfile(`user${id}`);
     const content = {
       type: 'doc',
       content: [
@@ -132,6 +133,8 @@ export const handlers = [
       title: `Post title ${id}`,
       image: `https://picsum.photos/seed/${seed}/600/400`,
       date: new Date().toISOString(),
+      views: Number(id) * 10,
+      author: { userId: author.userId, username: author.username, imageUrl: author.imageUrl },
       content,
     });
   }),

--- a/src/pages/Post.tsx
+++ b/src/pages/Post.tsx
@@ -1,5 +1,5 @@
 import { useParams, useNavigate } from 'react-router-dom';
-import { getNextPosts, fetchPost, type Post } from '@/lib/posts';
+import { fetchPost, type Post } from '@/lib/posts';
 import Viewer from '@/components/Viewer';
 import Comments from '@/components/Comments';
 import { useEffect, useState } from 'react';
@@ -10,7 +10,6 @@ export default function PostPage() {
   const id = Number(params.postId ?? params.id);
   const [post, setPost] = useState<Post | null>(null);
   const [loading, setLoading] = useState(true);
-  const nextPosts = getNextPosts(id, 3);
 
   useEffect(() => {
     setLoading(true);
@@ -20,42 +19,52 @@ export default function PostPage() {
       .finally(() => setLoading(false));
   }, [id]);
 
-  const go = (postId: number) => {
-    document.startViewTransition(() => {
-      navigate(`/post/${postId}`);
-    });
-  };
-
   if (loading) return <p className="p-4">Loading...</p>;
   if (!post) return <p className="p-4">No post</p>;
 
   return (
-    <div className="mx-auto flex max-w-5xl p-4">
-      <article className="flex-1">
-        <button onClick={() => navigate(-1)} className="mb-4 text-sm text-blue-500">
-          &larr; Back
+    <div className="mx-auto max-w-[1440px] space-y-4 p-4">
+      <button onClick={() => navigate(-1)} className="text-sm text-blue-500">
+        &larr; Back
+      </button>
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">{post.title}</h1>
+        <button
+          onClick={() => {
+            if (navigator.share) {
+              navigator.share({ title: post.title, url: window.location.href });
+            } else {
+              navigator.clipboard.writeText(window.location.href);
+              alert('Link copied');
+            }
+          }}
+          className="text-sm text-blue-500"
+        >
+          Share
         </button>
-        <h1 className="mb-2 text-2xl font-bold">{post.title}</h1>
-        <p className="text-sm text-gray-500">{new Date(post.date).toDateString()}</p>
-        <div style={{ viewTransitionName: `post-${post.id}` }}>
-          <img src={post.image} alt={post.title} className="my-4 w-full rounded-md" />
-        </div>
-        <Viewer content={post.content} />
-        <Comments postId={String(id)} />
-      </article>
-      <aside className="ml-8 hidden w-64 space-y-4 md:block">
-        {nextPosts.map((p) => (
-          <div key={p.id} onClick={() => go(p.id)} className="cursor-pointer">
-            <div
-              style={{ viewTransitionName: `post-${p.id}`, height: 80 }}
-              className="overflow-hidden rounded-md bg-gray-100"
-            >
-              <img src={p.image} alt={p.title} className="h-full w-full object-cover" />
-            </div>
-            <h3 className="mt-1 text-sm">{p.title}</h3>
-          </div>
-        ))}
-      </aside>
+      </div>
+      <div className="flex items-center space-x-2">
+        <img
+          onClick={() => navigate(`/profile/${post.author.userId}`)}
+          src={post.author.imageUrl}
+          alt={post.author.username}
+          className="h-8 w-8 cursor-pointer rounded-full object-cover"
+        />
+        <button
+          className="text-sm font-semibold"
+          onClick={() => navigate(`/profile/${post.author.userId}`)}
+        >
+          {post.author.username}
+        </button>
+      </div>
+      <p className="text-sm text-gray-500">
+        {new Date(post.date).toLocaleString()} · {post.views} views
+      </p>
+      <div style={{ viewTransitionName: `post-${post.id}` }}>
+        <img src={post.image} alt={post.title} className="my-4 w-full rounded-md" />
+      </div>
+      <Viewer content={post.content} className="w-full" />
+      <Comments postId={String(id)} />
     </div>
   );
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -51,5 +51,6 @@ placeholder:after {
   font-weight: bold;
 }
 .ProseMirror img {
-  max-width: 100px;
+  max-width: 100%;
+  width: 100%;
 }


### PR DESCRIPTION
## Summary
- expand `Post` model with author and view count
- mock author and view data in MSW handler
- support custom className on `Viewer`
- widen editor wrapper and images
- redesign single post page with author info and share button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68535f2d83ac8320906c96bfc22c9e97