### PR TITLE
Enable ESM support

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "name": "folks-frontend",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
-    "dev": "ts-node --transpile-only --project server/tsconfig.json server/index.ts",
+    "dev": "TS_NODE_PROJECT=server/tsconfig.json node --loader ts-node/esm server/index.ts",
     "build": "vite build && vite build --config vite.ssr.config.ts && tsc -p server",
     "start": "NODE_ENV=production node dist/server/index.js",
     "lint": "eslint .",

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,5 +1,8 @@
 import express, { Request, Response } from 'express'
-import path from 'path'
+import path from 'path';
+import { fileURLToPath } from 'url'
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 import fs from 'fs'
 import { createServer as createViteServer, ViteDevServer } from 'vite'
 
@@ -45,10 +48,10 @@ async function startServer() {
           'utf-8'
         )
         
-        // entry-server.mjs is an ES module, so use dynamic import instead of require
+        // entry-server.js is an ES module, so use dynamic import instead of require
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-expect-error no type definitions for mjs module
-        render = (await import('./entry-server.mjs')).render
+        // @ts-expect-error no type definitions for js module
+        render = (await import('./entry-server.js')).render
 
         // manifest.json에서 CSS 파일 추출
         const manifestPath = path.join(root, 'client/manifest.json')

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "outDir": "../dist/server",
-    "module": "commonjs",
+    "module": "esnext",
     "target": "ES2019",
     "lib": ["ES2019"],
     "noEmit": false,
@@ -10,5 +10,6 @@
     "moduleResolution": "node",
     "skipLibCheck": true
   },
-  "include": ["./**/*.ts"]
+  "include": ["./**/*.ts"],
+  "ts-node": {"esm": true}
 }


### PR DESCRIPTION
## Summary
- switch project to use Node ESM modules
- update dev script to use ts-node loader
- update server to work under ESM
- fix production import path

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run start` then `curl -s http://localhost:3000 | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68549f2b1b988320bb5fec41f171061a