### PR TITLE
Fix server-render crash in Editor

### DIFF
--- a/src/components/Editor/index.tsx
+++ b/src/components/Editor/index.tsx
@@ -12,8 +12,12 @@ interface EditorProps {
 }
 
 export const Editor: React.FC<EditorProps> = React.memo(({ value , onChange}: EditorProps) => {
+  if (typeof window === "undefined") {
+    // Avoid initializing ProseMirror on the server
+    return <div className="editor-wrapper" />;
+  }
   const ref = useRef<HTMLDivElement>(null);
-  const editorRef = useRef<EditorView>(null!);
+  const editorRef = useRef<EditorView | null>(null);
   const schema = editorSchema;
   const doc = Node.fromJSON(schema, value);
   const plugins = setup({ schema });


### PR DESCRIPTION
## Summary
- avoid ProseMirror initialization on the server to prevent editor issues after build

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6854c21a61b483208886ff3e3001882a