### PR TITLE
Fix msw in prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,16 @@
 
 ### Mock API
 개발 편의를 위해 [MSW](https://mswjs.io/) 기반의 목 API가 준비되어 있습니다.
-다음 명령으로 실행할 수 있습니다.
+개발 모드에서는 기본적으로 MSW가 활성화되며, 필요한 경우 아래와 같이 명시적으로 설정할 수 있습니다.
 
 ```bash
+# MSW 사용
 PUBLIC_API_MOCKING=enabled npm run dev
+# 실제 API 사용
+PUBLIC_API_MOCKING=disabled npm run dev
 ```
+
+프로덕션 빌드에서는 기본적으로 MSW가 비활성화됩니다.
 
 로그인은 아래 계정으로 가능합니다.
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -9,6 +9,9 @@ import { createServer as createViteServer, ViteDevServer } from 'vite'
 async function startServer() {
   const app = express()
   const isProd = process.env.NODE_ENV === 'production'
+  const isMocking = process.env.PUBLIC_API_MOCKING
+    ? process.env.PUBLIC_API_MOCKING === 'enabled'
+    : !isProd
   const root = path.resolve(__dirname, '..')
   let vite: ViteDevServer | undefined
 
@@ -25,9 +28,11 @@ async function startServer() {
     app.use('/public', express.static(path.join(root, 'public')))
   }
 
-  app.get('/mockServiceWorker.js', (_req, res) => {
-    res.sendFile(path.join(root, 'public/mockServiceWorker.js'))
-  })
+  if (isMocking) {
+    app.get('/mockServiceWorker.js', (_req, res) => {
+      res.sendFile(path.join(root, 'public/mockServiceWorker.js'))
+    })
+  }
 
   app.use('*', async (req: Request, res: Response) => {
     try {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,7 +5,8 @@ import App from './App';
 import { MetaProvider } from './lib/meta';
 
 async function start() {
-  const mocking = (import.meta as any).env.PUBLIC_API_MOCKING ?? 'enabled';
+  const env = (import.meta as any).env;
+  const mocking = env.PUBLIC_API_MOCKING ?? (env.DEV ? 'enabled' : 'disabled');
   if (mocking === 'enabled') {
     const { worker } = await import('./mocks/browser');
     await worker.start({


### PR DESCRIPTION
## Summary
- disable msw when NODE_ENV=production by default
- conditionally serve mockServiceWorker based on env
- document how to enable/disable msw in dev

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6854c782c9d88320be59c6cc0b5de704