### PR TITLE
Implement UI for post, crew, brand pages

### DIFF
--- a/src/components/AdBadge.tsx
+++ b/src/components/AdBadge.tsx
@@ -1,0 +1,7 @@
+export default function AdBadge() {
+  return (
+    <span className="absolute right-2 top-2 rounded bg-yellow-300 px-1 text-xs font-bold">
+      AD
+    </span>
+  );
+}

--- a/src/components/CrewBanner.tsx
+++ b/src/components/CrewBanner.tsx
@@ -1,0 +1,14 @@
+import { useNavigate } from 'react-router-dom';
+
+export default function CrewBanner({ crew }: { crew: { id: string; name: string } }) {
+  const navigate = useNavigate();
+  if (!crew) return null;
+  return (
+    <div
+      onClick={() => navigate(`/crew/${crew.id}`)}
+      className="cursor-pointer rounded bg-blue-100 px-3 py-2 text-sm font-semibold"
+    >
+      by {crew.name}
+    </div>
+  );
+}

--- a/src/components/TagList.tsx
+++ b/src/components/TagList.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function TagList({ tags }: { tags: string[] }) {
+  if (!tags || tags.length === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-2 py-2">
+      {tags.map((tag) => (
+        <span key={tag} className="rounded bg-gray-200 px-2 py-1 text-xs">
+          #{tag}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/brand.ts
+++ b/src/lib/brand.ts
@@ -1,0 +1,22 @@
+import { API_BASE } from './auth';
+import type { Post } from './posts';
+
+export interface Brand {
+  id: string;
+  name: string;
+  logo: string;
+  description: string;
+  links: { title: string; url: string }[];
+}
+
+export async function fetchBrand(id: string): Promise<Brand> {
+  const res = await fetch(`${API_BASE}/brands/${id}`, { cache: 'no-store' });
+  if (!res.ok) throw new Error('Failed to load brand');
+  return res.json();
+}
+
+export async function fetchBrandPosts(id: string): Promise<Post[]> {
+  const res = await fetch(`${API_BASE}/brands/${id}/posts`, { cache: 'no-store' });
+  if (!res.ok) throw new Error('Failed to load posts');
+  return res.json();
+}

--- a/src/lib/crew.ts
+++ b/src/lib/crew.ts
@@ -1,0 +1,22 @@
+import { API_BASE } from './auth';
+import type { Post } from './posts';
+
+export interface Crew {
+  id: string;
+  name: string;
+  coverImage: string;
+  description: string;
+  links: { title: string; url: string }[];
+}
+
+export async function fetchCrew(id: string): Promise<Crew> {
+  const res = await fetch(`${API_BASE}/crews/${id}`, { cache: 'no-store' });
+  if (!res.ok) throw new Error('Failed to load crew');
+  return res.json();
+}
+
+export async function fetchCrewPosts(id: string): Promise<Post[]> {
+  const res = await fetch(`${API_BASE}/crews/${id}/posts`, { cache: 'no-store' });
+  if (!res.ok) throw new Error('Failed to load posts');
+  return res.json();
+}

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -8,6 +8,9 @@ export interface Post {
   date: string;
   views: number;
   author: SimpleUser;
+  tags?: string[];
+  crew?: { id: string; name: string };
+  brand?: { id: string; name: string };
   content: any; // ProseMirror JSON
 }
 
@@ -26,6 +29,9 @@ export function mockPost(id: number): Post {
     date: new Date(BASE_TIME - id * 24 * 60 * 60 * 1000).toISOString(),
     views: id * 10,
     author,
+    tags: [`tag${id}`, `tag${id + 1}`],
+    crew: id % 2 === 0 ? { id: `crew${id}`, name: `Crew ${id}` } : undefined,
+    brand: id % 3 === 0 ? { id: `brand${id}`, name: `Brand ${id}` } : undefined,
     content: {
       type: 'doc',
       content: [

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -39,6 +39,34 @@ function randomProfile(id: string): Profile {
   };
 }
 
+function randomPost(id: number) {
+  const seed = Math.random().toString(36).slice(2, 8);
+  const author = randomProfile(`user${id}`);
+  const content = {
+    type: 'doc',
+    content: [
+      {
+        type: 'paragraph',
+        content: [
+          { type: 'text', text: `Random post ${id}` },
+        ],
+      },
+    ],
+  };
+  return {
+    id,
+    title: `Post title ${id}`,
+    image: `https://picsum.photos/seed/${seed}/600/400`,
+    date: new Date().toISOString(),
+    views: id * 10,
+    author: { userId: author.userId, username: author.username, imageUrl: author.imageUrl },
+    tags: [`tag${id}`, `tag${id + 1}`],
+    crew: id % 2 === 0 ? { id: `crew${id}`, name: `Crew ${id}` } : undefined,
+    brand: id % 3 === 0 ? { id: `brand${id}`, name: `Brand ${id}` } : undefined,
+    content,
+  };
+}
+
 export const handlers = [
   http.post(`${API_BASE}/auth/login`, async ({ request }) => {
     const { email, password } = await request.json();
@@ -81,61 +109,44 @@ export const handlers = [
 
   http.get(`${API_BASE}/posts/:id`, ({ params }) => {
     const { id } = params as { id: string };
-    const seed = Math.random().toString(36).slice(2, 8);
-    const author = randomProfile(`user${id}`);
-    const content = {
-      type: 'doc',
-      content: [
-        {
-          type: 'paragraph',
-          content: [
-            { type: 'text', text: `Random post ${id}` },
-            { type: 'text', text: `this is new text` },
-          ],
-        },
-        {
-          type: 'paragraph',
-          content: [
-            {
-              type: 'text',
-              text: '다양한 스타일의 문단 ' ,
-              marks: [
-                { type: 'font', attrs: { name: 'Georgia' } },
-                { type: 'color', attrs: { color: 'blue' } },
-              ],
-            },
-            { type: 'text', text: '😊' },
-          ],
-        },
-        {
-          type: 'image',
-          attrs: {
-            src: `https://picsum.photos/seed/${seed+1}/600/400`,
-            alt: 'random image',
-          },
-        },
-        {
-          type: 'paragraph',
-          content: [
-            {
-              type: 'text',
-              text: 'Comic Sans 폰트의 문단입니다.',
-              marks: [
-                { type: 'font', attrs: { name: 'Comic Sans MS' } },
-              ],
-            },
-          ],
-        },
-      ],
-    };
+    return HttpResponse.json(randomPost(Number(id)));
+  }),
+
+  http.get(`${API_BASE}/crews/:id`, ({ params }) => {
+    const { id } = params as { id: string };
     return HttpResponse.json({
-      id: Number(id),
-      title: `Post title ${id}`,
-      image: `https://picsum.photos/seed/${seed}/600/400`,
-      date: new Date().toISOString(),
-      views: Number(id) * 10,
-      author: { userId: author.userId, username: author.username, imageUrl: author.imageUrl },
-      content,
+      id,
+      name: `Crew ${id}`,
+      coverImage: `https://picsum.photos/seed/crew-${id}/1200/300`,
+      description: `This is crew ${id}.`,
+      links: [
+        { title: 'Instagram', url: 'https://instagram.com' },
+      ],
     });
+  }),
+
+  http.get(`${API_BASE}/crews/:id/posts`, ({ params }) => {
+    const { id } = params as { id: string };
+    const posts = Array.from({ length: 4 }, (_, i) => randomPost(i + 1));
+    return HttpResponse.json(posts);
+  }),
+
+  http.get(`${API_BASE}/brands/:id`, ({ params }) => {
+    const { id } = params as { id: string };
+    return HttpResponse.json({
+      id,
+      name: `Brand ${id}`,
+      logo: `https://picsum.photos/seed/brand-${id}/200/200`,
+      description: `This is brand ${id}.`,
+      links: [
+        { title: 'Website', url: 'https://example.com' },
+      ],
+    });
+  }),
+
+  http.get(`${API_BASE}/brands/:id/posts`, ({ params }) => {
+    const { id } = params as { id: string };
+    const posts = Array.from({ length: 4 }, (_, i) => randomPost(i + 1));
+    return HttpResponse.json(posts);
   }),
 ];

--- a/src/pages/Brand.tsx
+++ b/src/pages/Brand.tsx
@@ -1,14 +1,48 @@
 import { useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
 import { useMeta } from '@/lib/meta';
+import { fetchBrand, fetchBrandPosts, type Brand } from '@/lib/brand';
+import type { Post } from '@/lib/posts';
+import PostCard from '@/components/PostCard';
+import AdBadge from '@/components/AdBadge';
 
 export default function BrandPage() {
   const params = useParams();
   const brandId = params.brandId as string;
-  useMeta({ title: `Brand ${brandId} - Stylefolks` });
+  const [brand, setBrand] = useState<Brand | null>(null);
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [loading, setLoading] = useState(true);
+  useMeta({ title: brand ? `${brand.name} - Stylefolks` : 'Brand - Stylefolks' });
+
+  useEffect(() => {
+    if (!brandId) return;
+    setLoading(true);
+    Promise.all([fetchBrand(brandId), fetchBrandPosts(brandId)])
+      .then(([b, p]) => {
+        setBrand(b);
+        setPosts(p);
+      })
+      .finally(() => setLoading(false));
+  }, [brandId]);
+
+  if (loading) return <p className="p-4">Loading...</p>;
+  if (!brand) return <p className="p-4">No brand</p>;
+
   return (
-    <div className="p-4">
-      <h1 className="text-xl font-bold">Brand {brandId}</h1>
-      <p className="text-sm text-gray-600">This is the brand page.</p>
+    <div className="mx-auto max-w-[720px] space-y-4 p-4">
+      <img src={brand.logo} alt={brand.name} className="h-24 w-24 rounded object-cover" />
+      <div>
+        <h1 className="text-xl font-bold">{brand.name}</h1>
+        <p className="text-sm text-gray-600">{brand.description}</p>
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        {posts.map((post) => (
+          <div className="relative" key={post.id}>
+            <AdBadge />
+            <PostCard post={post} />
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/pages/Crew.tsx
+++ b/src/pages/Crew.tsx
@@ -1,14 +1,44 @@
 import { useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
 import { useMeta } from '@/lib/meta';
+import { fetchCrew, fetchCrewPosts, type Crew } from '@/lib/crew';
+import type { Post } from '@/lib/posts';
+import PostCard from '@/components/PostCard';
 
 export default function CrewPage() {
   const params = useParams();
   const crewId = params.crewId as string;
-  useMeta({ title: `Crew ${crewId} - Stylefolks` });
+  const [crew, setCrew] = useState<Crew | null>(null);
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [loading, setLoading] = useState(true);
+  useMeta({ title: crew ? `${crew.name} - Stylefolks` : 'Crew - Stylefolks' });
+
+  useEffect(() => {
+    if (!crewId) return;
+    setLoading(true);
+    Promise.all([fetchCrew(crewId), fetchCrewPosts(crewId)])
+      .then(([c, p]) => {
+        setCrew(c);
+        setPosts(p);
+      })
+      .finally(() => setLoading(false));
+  }, [crewId]);
+
+  if (loading) return <p className="p-4">Loading...</p>;
+  if (!crew) return <p className="p-4">No crew</p>;
+
   return (
-    <div className="p-4">
-      <h1 className="text-xl font-bold">Crew {crewId}</h1>
-      <p className="text-sm text-gray-600">This is the crew page.</p>
+    <div className="mx-auto max-w-[720px] space-y-4 p-4">
+      <img src={crew.coverImage} alt={crew.name} className="h-40 w-full rounded object-cover" />
+      <div>
+        <h1 className="text-xl font-bold">{crew.name}</h1>
+        <p className="text-sm text-gray-600">{crew.description}</p>
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        {posts.map((post) => (
+          <PostCard key={post.id} post={post} />
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/pages/Post.tsx
+++ b/src/pages/Post.tsx
@@ -4,6 +4,9 @@ import Viewer from '@/components/Viewer';
 import Comments from '@/components/Comments';
 import { useEffect, useState } from 'react';
 import { useMeta } from '@/lib/meta';
+import TagList from '@/components/TagList';
+import CrewBanner from '@/components/CrewBanner';
+import AdBadge from '@/components/AdBadge';
 
 const PostTitlePart = ({ post }:{ post : Post   }) => {
   const navigate = useNavigate();
@@ -25,19 +28,22 @@ const PostTitlePart = ({ post }:{ post : Post   }) => {
       </button>
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">{post.title}</h1>
-        <button
-          onClick={() => {
-            if (navigator.share) {
-              navigator.share({ title: post.title, url: window.location.href });
-            } else {
-              navigator.clipboard.writeText(window.location.href);
-              alert('Link copied');
-            }
+        <div className="space-x-2">
+          <button
+            onClick={() => {
+              if (navigator.share) {
+                navigator.share({ title: post.title, url: window.location.href });
+              } else {
+                navigator.clipboard.writeText(window.location.href);
+                alert('Link copied');
+              }
           }}
           className="text-sm text-blue-500"
         >
           Share
         </button>
+          <button className="text-sm" onClick={() => alert('Liked!')}>❤️</button>
+        </div>
       </div>
       <div className="flex items-center space-x-2">
         <img
@@ -56,6 +62,9 @@ const PostTitlePart = ({ post }:{ post : Post   }) => {
       <p className="text-sm text-gray-500">
         {new Date(post.date).toLocaleString()} · {post.views} views
       </p>
+      {post.tags && <TagList tags={post.tags} />}
+      {post.crew && <CrewBanner crew={post.crew} />}
+      {post.brand && <div className="relative"><AdBadge /></div>}
       </>
   )
 }


### PR DESCRIPTION
## Summary
- show post tags, crew banner, brand badge
- add TagList, CrewBanner and AdBadge components
- implement crew and brand pages with sample feeds
- expand post, crew and brand mock routes
- support additional fields in Post type

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68550ea8ab808320ab47e90e35d5203d