### PR TITLE
Implement editable crew page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import Signup from '@/pages/Signup';
 import Posts from '@/pages/Posts';
 import Post from '@/pages/Post';
 import Crews from '@/pages/Crews';
-import Crew from '@/pages/Crew';
+import CrewDetailPage from '@/pages/crew/[id]';
 import Brand from '@/pages/Brand';
 import Profile from '@/pages/Profile';
 import MyProfile from '@/pages/MyProfile';
@@ -28,7 +28,7 @@ export default function App() {
           <Route path="/posts" element={<Posts />} />
           <Route path="/post/:postId" element={<Post />} />
           <Route path="/crews" element={<Crews />} />
-          <Route path="/crew/:crewId" element={<Crew />} />
+          <Route path="/crew/:id" element={<CrewDetailPage />} />
           <Route path="/brands" element={<Brands />} />
           <Route path="/brand/:brandId" element={<Brand />} />
           <Route element={<RequireAuth />}>

--- a/src/components/EditableImageUpload.tsx
+++ b/src/components/EditableImageUpload.tsx
@@ -1,0 +1,56 @@
+import { useRef } from 'react';
+import { cn } from '@/lib/utils';
+
+interface Props {
+  src?: string;
+  onChange: (file: File) => void;
+  isEditable?: boolean;
+  className?: string;
+  placeholderClassName?: string;
+}
+
+export default function EditableImageUpload({
+  src,
+  onChange,
+  isEditable,
+  className,
+  placeholderClassName,
+}: Props) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) onChange(file);
+  };
+
+  return (
+    <div
+      className={cn('relative group', className)}
+      onClick={() => {
+        if (isEditable) inputRef.current?.click();
+      }}
+    >
+      {src ? (
+        <img src={src} className="h-full w-full object-cover" />
+      ) : (
+        <div className={cn('flex h-full w-full items-center justify-center bg-gray-100 text-gray-400', placeholderClassName)}>
+          No image
+        </div>
+      )}
+      {isEditable && (
+        <div className="absolute inset-0 hidden items-center justify-center bg-black/50 text-white group-hover:flex">
+          <span className="px-2 py-1 text-sm">Upload</span>
+        </div>
+      )}
+      {isEditable && (
+        <input
+          type="file"
+          accept="image/*"
+          ref={inputRef}
+          onChange={handleFile}
+          className="hidden"
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/EditableLinkList.tsx
+++ b/src/components/EditableLinkList.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { Input } from './ui/input';
+import { Button } from './ui/button';
+
+export interface LinkItem {
+  title: string;
+  url: string;
+}
+
+interface Props {
+  links: LinkItem[];
+  onChange: (links: LinkItem[]) => void;
+  isEditable?: boolean;
+}
+
+export default function EditableLinkList({ links, onChange, isEditable }: Props) {
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+
+  const handleChange = (index: number, field: keyof LinkItem, value: string) => {
+    const updated = links.map((l, i) =>
+      i === index ? { ...l, [field]: value } : l,
+    );
+    onChange(updated);
+  };
+
+  const remove = (index: number) => {
+    onChange(links.filter((_, i) => i !== index));
+  };
+
+  const add = () => {
+    onChange([...links, { title: '', url: '' }]);
+    setEditingIndex(links.length);
+  };
+
+  if (!isEditable && links.length === 0) return null;
+
+  return (
+    <div className="space-y-2">
+      {links.map((link, i) => (
+        <div key={i} className="flex items-center gap-2">
+          {isEditable && editingIndex === i ? (
+            <>
+              <Input
+                value={link.title}
+                onChange={(e) => handleChange(i, 'title', e.target.value)}
+                placeholder="Title"
+                className="w-32"
+              />
+              <Input
+                value={link.url}
+                onChange={(e) => handleChange(i, 'url', e.target.value)}
+                placeholder="URL"
+              />
+              <Button
+                variant="outline"
+                onClick={() => setEditingIndex(null)}
+              >
+                Done
+              </Button>
+              <Button variant="outline" onClick={() => remove(i)}>
+                Remove
+              </Button>
+            </>
+          ) : (
+            <>
+              <a href={link.url} className="text-blue-600 underline" target="_blank" rel="noopener noreferrer">
+                {link.title || link.url}
+              </a>
+              {isEditable && (
+                <Button variant="outline" size="sm" onClick={() => setEditingIndex(i)}>
+                  Edit
+                </Button>
+              )}
+            </>
+          )}
+        </div>
+      ))}
+      {isEditable && (
+        <Button variant="outline" size="sm" onClick={add}>
+          {links.length === 0 ? 'SNS 추가하기' : 'Add link'}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/components/EditableText.tsx
+++ b/src/components/EditableText.tsx
@@ -1,0 +1,53 @@
+import { useState, useEffect } from 'react';
+import { cn } from '@/lib/utils';
+import { Input } from './ui/input';
+
+interface Props {
+  value: string;
+  onChange: (v: string) => void;
+  isEditable?: boolean;
+  as?: keyof JSX.IntrinsicElements;
+  placeholder?: string;
+  className?: string;
+}
+
+export default function EditableText({
+  value,
+  onChange,
+  isEditable,
+  as = 'span',
+  placeholder,
+  className,
+}: Props) {
+  const [editing, setEditing] = useState(false);
+  const [temp, setTemp] = useState(value);
+
+  useEffect(() => setTemp(value), [value]);
+
+  const Tag = as as any;
+
+  if (editing && isEditable) {
+    return (
+      <Input
+        value={temp}
+        onChange={(e) => setTemp(e.target.value)}
+        onBlur={() => {
+          setEditing(false);
+          onChange(temp);
+        }}
+        autoFocus
+        placeholder={placeholder}
+        className={className}
+      />
+    );
+  }
+
+  return (
+    <Tag
+      className={cn(isEditable && 'cursor-pointer', className)}
+      onClick={() => isEditable && setEditing(true)}
+    >
+      {value || placeholder}
+    </Tag>
+  );
+}

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -1,0 +1,17 @@
+import { Event } from '@/lib/crew';
+
+export default function EventCard({ event }: { event: Event }) {
+  return (
+    <div className="flex gap-2 rounded border p-2">
+      {event.image && (
+        <img src={event.image} className="h-20 w-20 rounded object-cover" />
+      )}
+      <div>
+        <h3 className="font-semibold">{event.title}</h3>
+        <p className="text-sm text-gray-500">
+          {event.date} @ {event.location}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TabNav.tsx
+++ b/src/components/TabNav.tsx
@@ -1,0 +1,31 @@
+interface Tab {
+  id: string;
+  title: string;
+}
+
+interface Props {
+  tabs: Tab[];
+  current: string;
+  onChange: (id: string) => void;
+  className?: string;
+}
+
+export default function TabNav({ tabs, current, onChange, className }: Props) {
+  return (
+    <div className={`flex border-b ${className || ''}`}>
+      {tabs.map((tab) => (
+        <button
+          key={tab.id}
+          onClick={() => onChange(tab.id)}
+          className={`px-3 py-2 text-sm font-medium ${
+            current === tab.id
+              ? 'border-b-2 border-black'
+              : 'text-gray-500'
+          }`}
+        >
+          {tab.title}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/crew.ts
+++ b/src/lib/crew.ts
@@ -1,12 +1,33 @@
 import { API_BASE } from './auth';
 import type { Post } from './posts';
 
+export interface CrewLink {
+  title: string;
+  url: string;
+}
+
+export interface Event {
+  id: string;
+  title: string;
+  date: string;
+  location: string;
+  image?: string;
+}
+
+export interface Notice {
+  id: string;
+  title: string;
+  content: string;
+  date: string;
+}
+
 export interface Crew {
   id: string;
   name: string;
   coverImage: string;
   description: string;
-  links: { title: string; url: string }[];
+  links: CrewLink[];
+  ownerId: string;
 }
 
 export async function fetchCrew(id: string): Promise<Crew> {
@@ -18,5 +39,17 @@ export async function fetchCrew(id: string): Promise<Crew> {
 export async function fetchCrewPosts(id: string): Promise<Post[]> {
   const res = await fetch(`${API_BASE}/crews/${id}/posts`, { cache: 'no-store' });
   if (!res.ok) throw new Error('Failed to load posts');
+  return res.json();
+}
+
+export async function fetchCrewEvents(id: string): Promise<Event[]> {
+  const res = await fetch(`${API_BASE}/crews/${id}/events`, { cache: 'no-store' });
+  if (!res.ok) throw new Error('Failed to load events');
+  return res.json();
+}
+
+export async function fetchCrewNotices(id: string): Promise<Notice[]> {
+  const res = await fetch(`${API_BASE}/crews/${id}/notices`, { cache: 'no-store' });
+  if (!res.ok) throw new Error('Failed to load notices');
   return res.json();
 }

--- a/src/pages/crew/[id].tsx
+++ b/src/pages/crew/[id].tsx
@@ -1,0 +1,142 @@
+import { useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useMeta } from '@/lib/meta';
+import {
+  fetchCrew,
+  fetchCrewPosts,
+  fetchCrewEvents,
+  fetchCrewNotices,
+  type Crew,
+  type Event,
+  type Notice,
+} from '@/lib/crew';
+import type { Post } from '@/lib/posts';
+import { getMyId } from '@/lib/auth';
+import PostCard from '@/components/PostCard';
+import EditableText from '@/components/EditableText';
+import EditableImageUpload from '@/components/EditableImageUpload';
+import EditableLinkList from '@/components/EditableLinkList';
+import TabNav from '@/components/TabNav';
+import EventCard from '@/components/EventCard';
+
+export default function CrewDetailPage() {
+  const params = useParams();
+  const crewId = params.id as string;
+
+  const [crew, setCrew] = useState<Crew | null>(null);
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [events, setEvents] = useState<Event[]>([]);
+  const [notices, setNotices] = useState<Notice[]>([]);
+  const [tab, setTab] = useState('feed');
+  const [currentUser, setCurrentUser] = useState<string | null>(null);
+  const [about, setAbout] = useState('');
+
+  useMeta({ title: crew ? `${crew.name} - Stylefolks` : 'Crew - Stylefolks' });
+
+  useEffect(() => {
+    getMyId().then(setCurrentUser).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (!crewId) return;
+    Promise.all([
+      fetchCrew(crewId),
+      fetchCrewPosts(crewId),
+      fetchCrewEvents(crewId).catch(() => []),
+      fetchCrewNotices(crewId).catch(() => []),
+    ]).then(([c, p, e, n]) => {
+      setCrew(c);
+      setPosts(p);
+      setEvents(e as Event[]);
+      setNotices(n as Notice[]);
+      setAbout(c.description);
+    });
+  }, [crewId]);
+
+  if (!crew) return <p className="p-4">Loading...</p>;
+
+  const isEditable = currentUser === crew.ownerId;
+
+  const updateName = (name: string) => setCrew({ ...(crew as Crew), name });
+  const updateDescription = (description: string) =>
+    setCrew({ ...(crew as Crew), description });
+  const updateCover = (file: File) => {
+    const url = URL.createObjectURL(file);
+    setCrew({ ...(crew as Crew), coverImage: url });
+  };
+  const updateLinks = (links: any) => setCrew({ ...(crew as Crew), links });
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-4 p-4">
+      <EditableImageUpload
+        src={crew.coverImage}
+        onChange={updateCover}
+        isEditable={isEditable}
+        className="h-40 w-full rounded"
+      />
+      <EditableText
+        as="h1"
+        value={crew.name}
+        onChange={updateName}
+        isEditable={isEditable}
+        className="text-xl font-bold"
+      />
+      <EditableText
+        as="p"
+        value={crew.description}
+        onChange={updateDescription}
+        isEditable={isEditable}
+        placeholder="Short description"
+        className="text-sm text-gray-600"
+      />
+      <EditableLinkList
+        links={crew.links}
+        onChange={updateLinks}
+        isEditable={isEditable}
+      />
+      <TabNav
+        tabs={[
+          { id: 'feed', title: 'Feed' },
+          { id: 'events', title: 'Events' },
+          { id: 'notice', title: 'Notice' },
+          { id: 'about', title: 'About' },
+        ]}
+        current={tab}
+        onChange={setTab}
+      />
+      {tab === 'feed' && (
+        <div className="grid grid-cols-2 gap-4">
+          {posts.map((post) => (
+            <PostCard key={post.id} post={post} />
+          ))}
+        </div>
+      )}
+      {tab === 'events' && (
+        <div className="space-y-2">
+          {events.map((event) => (
+            <EventCard key={event.id} event={event} />
+          ))}
+        </div>
+      )}
+      {tab === 'notice' && (
+        <ul className="space-y-2">
+          {notices.map((n) => (
+            <li key={n.id} className="rounded border p-2">
+              <h3 className="font-semibold">{n.title}</h3>
+              <p className="text-sm text-gray-500">{n.date}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+      {tab === 'about' && (
+        <EditableText
+          as="div"
+          value={about}
+          onChange={setAbout}
+          isEditable={isEditable}
+          className="min-h-[80px]"
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add components for editing crew details
- extend crew library with events and notices
- create new dynamic crew page with editable sections
- update app routing to use new crew page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685519ef96748320b1b1877e526568d0