### PR TITLE
Implement brand detail page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import Posts from '@/pages/Posts';
 import Post from '@/pages/Post';
 import Crews from '@/pages/Crews';
 import CrewDetailPage from '@/pages/crew/[id]';
-import Brand from '@/pages/Brand';
+import BrandDetailPage from '@/pages/brand/[id]';
 import Profile from '@/pages/Profile';
 import MyProfile from '@/pages/MyProfile';
 import SettingsPage from '@/pages/Settings';
@@ -30,7 +30,7 @@ export default function App() {
           <Route path="/crews" element={<Crews />} />
           <Route path="/crew/:id" element={<CrewDetailPage />} />
           <Route path="/brands" element={<Brands />} />
-          <Route path="/brand/:brandId" element={<Brand />} />
+          <Route path="/brand/:id" element={<BrandDetailPage />} />
           <Route element={<RequireAuth />}>
             <Route path="/profile" element={<MyProfile />} />
             <Route path="/profile/:userId" element={<Profile />} />

--- a/src/components/brand/BrandHeader.tsx
+++ b/src/components/brand/BrandHeader.tsx
@@ -1,0 +1,25 @@
+import { Brand } from '@/lib/brand';
+import ExternalLinkList from './ExternalLinkList';
+
+interface Props {
+  brand: Brand;
+}
+
+export default function BrandHeader({ brand }: Props) {
+  return (
+    <div className="space-y-2 text-center">
+      <img
+        src={brand.logo}
+        alt={brand.name}
+        className="mx-auto h-24 w-24 rounded-full object-cover"
+      />
+      <h1 className="text-xl font-bold">{brand.name}</h1>
+      {brand.description && (
+        <p className="text-sm text-gray-600">{brand.description}</p>
+      )}
+      {brand.links && brand.links.length > 0 && (
+        <ExternalLinkList links={brand.links} />
+      )}
+    </div>
+  );
+}

--- a/src/components/brand/BrandPostCard.tsx
+++ b/src/components/brand/BrandPostCard.tsx
@@ -1,0 +1,12 @@
+import type { Post } from '@/lib/posts';
+import PostCard from '@/components/PostCard';
+import AdBadge from '@/components/AdBadge';
+
+export default function BrandPostCard({ post }: { post: Post }) {
+  return (
+    <div className="relative">
+      {post.isSponsored && <AdBadge />}
+      <PostCard post={post} />
+    </div>
+  );
+}

--- a/src/components/brand/ExternalLinkList.tsx
+++ b/src/components/brand/ExternalLinkList.tsx
@@ -1,0 +1,23 @@
+interface LinkItem {
+  title: string;
+  url: string;
+}
+
+export default function ExternalLinkList({ links }: { links: LinkItem[] }) {
+  return (
+    <ul className="flex justify-center gap-2">
+      {links.map((link) => (
+        <li key={link.url}>
+          <a
+            href={link.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 underline"
+          >
+            {link.title}
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/brand/PostList.tsx
+++ b/src/components/brand/PostList.tsx
@@ -1,0 +1,18 @@
+import BrandPostCard from './BrandPostCard';
+import type { Post } from '@/lib/posts';
+
+export default function PostList({ posts }: { posts: Post[] }) {
+  if (posts.length === 0) return <p>No posts</p>;
+  const promoted = posts.filter((p) => p.isPromoted);
+  const normal = posts.filter((p) => !p.isPromoted);
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      {promoted.map((post) => (
+        <BrandPostCard key={post.id} post={post} />
+      ))}
+      {normal.map((post) => (
+        <BrandPostCard key={post.id} post={post} />
+      ))}
+    </div>
+  );
+}

--- a/src/pages/brand/[id].tsx
+++ b/src/pages/brand/[id].tsx
@@ -1,0 +1,44 @@
+import { useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useMeta } from '@/lib/meta';
+import { fetchBrand, fetchBrandPosts, Brand } from '@/lib/brand';
+import type { Post } from '@/lib/posts';
+import BrandHeader from '@/components/brand/BrandHeader';
+import PostList from '@/components/brand/PostList';
+
+export default function BrandDetailPage() {
+  const params = useParams();
+  const id = params.id as string;
+  const [brand, setBrand] = useState<Brand | null>(null);
+  const [posts, setPosts] = useState<Post[]>([]);
+
+  useMeta({ title: brand ? `${brand.name} - Stylefolks` : 'Brand - Stylefolks' });
+
+  useEffect(() => {
+    if (!id) return;
+    Promise.all([fetchBrand(id), fetchBrandPosts(id)])
+      .then(([b, p]) => {
+        setBrand(b);
+        setPosts(p);
+      })
+      .catch(() => {});
+  }, [id]);
+
+  if (!brand) return <p className="p-4">Loading...</p>;
+
+  const brandPosts = posts.filter((post: any) => post.type === 'BRAND');
+
+  // latest first
+  brandPosts.sort((a, b) => {
+    const pA = a.isPromoted === b.isPromoted ? 0 : a.isPromoted ? -1 : 1;
+    if (pA !== 0) return pA;
+    return new Date(b.date).getTime() - new Date(a.date).getTime();
+  });
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-4 p-4">
+      <BrandHeader brand={brand} />
+      <PostList posts={brandPosts} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add brand page `/brand/:id` with brand info header and posts list
- show external links and AD badge for sponsored posts
- render promoted posts first
- wire new page into router

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68551d1fb55483208c972502b40d72bc