### PR TITLE
Implement search page with reusable UI components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Post from '@/pages/Post';
 import Crews from '@/pages/Crews';
 import CrewDetailPage from '@/pages/crew/[id]';
 import BrandDetailPage from '@/pages/brand/[id]';
+import SearchPage from '@/pages/Search';
 import Profile from '@/pages/Profile';
 import MyProfile from '@/pages/MyProfile';
 import SettingsPage from '@/pages/Settings';
@@ -30,6 +31,7 @@ export default function App() {
           <Route path="/crew/:id" element={<CrewDetailPage />} />
           <Route path="/brands" element={<Brands />} />
           <Route path="/brand/:id" element={<BrandDetailPage />} />
+          <Route path="/search" element={<SearchPage />} />
           <Route element={<RequireAuth />}>
             <Route path="/profile" element={<MyProfile />} />
             <Route path="/profile/:userId" element={<Profile />} />

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -27,6 +27,9 @@ export default function MobileNav({ open, onClose, loggedIn }: MobileNavProps) {
         onClick={(e) => e.stopPropagation()}
       >
         <nav className="flex flex-col gap-4">
+          <Link to="/search" onClick={onClose} className="py-2">
+            Search
+          </Link>
           <Link to="/posts" onClick={onClose} className="py-2">
             Posts
           </Link>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -44,6 +44,13 @@ export default function Navbar() {
         <Link to="/brands" className="hidden sm:inline-block">
           Brands
         </Link>
+        <Link
+          to="/search"
+          aria-label="Search"
+          className={location.pathname === '/search' ? 'border p-1 rounded' : ''}
+        >
+          🔍
+        </Link>
         <Link to="/write" className="hidden sm:inline-block">
           Write
         </Link>

--- a/src/components/search/EmptyState.tsx
+++ b/src/components/search/EmptyState.tsx
@@ -1,0 +1,7 @@
+export default function EmptyState() {
+  return (
+    <p className="py-8 text-center text-sm text-gray-500">
+      아직 이 스타일의 글은 없어요. CREW를 팔로우해보세요!
+    </p>
+  );
+}

--- a/src/components/search/PostTypeTabs.tsx
+++ b/src/components/search/PostTypeTabs.tsx
@@ -1,0 +1,28 @@
+import { cn } from '@/lib/utils';
+
+const TYPES = ['ALL', 'TALK', 'COLUMN', 'CREW', 'BRAND'] as const;
+export type PostType = typeof TYPES[number];
+
+interface Props {
+  value: PostType;
+  onChange: (value: PostType) => void;
+}
+
+export default function PostTypeTabs({ value, onChange }: Props) {
+  return (
+    <div className="flex gap-4 overflow-x-auto">
+      {TYPES.map((type) => (
+        <button
+          key={type}
+          onClick={() => onChange(type)}
+          className={cn(
+            'pb-1 text-sm whitespace-nowrap',
+            value === type ? 'border-b-2 border-black font-semibold' : 'text-gray-500'
+          )}
+        >
+          {type === 'ALL' ? '전체' : type}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/search/SearchInput.tsx
+++ b/src/components/search/SearchInput.tsx
@@ -1,0 +1,19 @@
+import { Input } from '../ui/input';
+
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+export default function SearchInput({ value, onChange, placeholder = '어떤 스타일이 궁금하세요?' }: Props) {
+  return (
+    <Input
+      type="search"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+      className="rounded-full"
+    />
+  );
+}

--- a/src/components/search/TagFilterChips.tsx
+++ b/src/components/search/TagFilterChips.tsx
@@ -1,0 +1,35 @@
+import { cn } from '@/lib/utils';
+
+interface Props {
+  tags: string[];
+  selected: string[];
+  onChange: (tags: string[]) => void;
+}
+
+export default function TagFilterChips({ tags, selected, onChange }: Props) {
+  const toggle = (tag: string) => {
+    if (selected.includes(tag)) {
+      onChange(selected.filter((t) => t !== tag));
+    } else {
+      onChange([...selected, tag]);
+    }
+  };
+  return (
+    <div className="flex gap-2 overflow-x-auto py-1">
+      {tags.map((tag) => (
+        <button
+          key={tag}
+          onClick={() => toggle(tag)}
+          className={cn(
+            'rounded-full border px-3 py-1 text-sm whitespace-nowrap',
+            selected.includes(tag)
+              ? 'bg-black text-white border-black'
+              : 'bg-gray-100 text-gray-700'
+          )}
+        >
+          #{tag}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -1,0 +1,80 @@
+import { useState, useEffect, useCallback } from 'react';
+import SearchInput from '@/components/search/SearchInput';
+import PostTypeTabs, { PostType } from '@/components/search/PostTypeTabs';
+import TagFilterChips from '@/components/search/TagFilterChips';
+import EmptyState from '@/components/search/EmptyState';
+import PostCard from '@/components/PostCard';
+import useInfiniteScroll from '@/components/useInfiniteScroll';
+import { getNextPosts, type Post } from '@/lib/posts';
+import { useMeta } from '@/lib/meta';
+
+const TAGS = ['빈티지', '루즈핏', '페미닌룩', '테크노', '홍대파티'];
+const PAGE_SIZE = 10;
+
+function filterByType(post: Post, type: PostType) {
+  switch (type) {
+    case 'CREW':
+      return !!post.crew;
+    case 'BRAND':
+      return !!post.brand;
+    case 'TALK':
+      return !post.crew && !post.brand;
+    case 'COLUMN':
+      return !!post.author;
+    default:
+      return true;
+  }
+}
+
+export default function SearchPage() {
+  useMeta({ title: 'Search - Stylefolks' });
+  const [query, setQuery] = useState('');
+  const [type, setType] = useState<PostType>('ALL');
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [nextId, setNextId] = useState(0);
+
+  const applyFilters = useCallback(
+    (list: Post[]) =>
+      list.filter((p) => {
+        const matchesQuery = !query || p.title.includes(query);
+        const matchesTags = selectedTags.every((t) => p.tags?.includes(t));
+        const matchesType = filterByType(p, type);
+        return matchesQuery && matchesTags && matchesType;
+      }),
+    [query, selectedTags, type]
+  );
+
+  const loadMore = useCallback(() => {
+    const fetched = getNextPosts(nextId, PAGE_SIZE);
+    const filtered = applyFilters(fetched);
+    setPosts((prev) => [...prev, ...filtered]);
+    setNextId((id) => id + PAGE_SIZE);
+  }, [nextId, applyFilters]);
+
+  const ref = useInfiniteScroll(loadMore);
+
+  useEffect(() => {
+    const initial = applyFilters(getNextPosts(0, PAGE_SIZE));
+    setPosts(initial);
+    setNextId(PAGE_SIZE);
+  }, [query, selectedTags, type, applyFilters]);
+
+  return (
+    <div className="p-4 space-y-4">
+      <SearchInput value={query} onChange={setQuery} />
+      <PostTypeTabs value={type} onChange={setType} />
+      <TagFilterChips tags={TAGS} selected={selectedTags} onChange={setSelectedTags} />
+      {posts.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <div className="grid grid-cols-2 gap-4">
+          {posts.map((post) => (
+            <PostCard key={post.id} post={post} />
+          ))}
+          <div ref={ref} />
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement search specific UI components
- create `/search` page using the new components
- link search page in routing and navbar
- add search entry in mobile nav

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68556dcf85a483209f73a428159560fb