### PR TITLE
Add profile icon and simplify bottom nav

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import MobileNav from './MobileNav';
 import { getToken } from '@/lib/auth';
 import TopNav from './navigation/TopNav';
+import Avatar from './ui/avatar';
 
 export default function Navbar() {
   const location = useLocation();
@@ -27,6 +28,11 @@ export default function Navbar() {
         Folks
       </Link>
       <div className="flex gap-4 items-center">
+        {loggedIn && (
+          <Link to="/profile/me" aria-label="Profile">
+            <Avatar size="sm" />
+          </Link>
+        )}
         <button
           className="sm:hidden p-2"
           onClick={() => setMobileOpen(true)}

--- a/src/components/navigation/BottomNav.tsx
+++ b/src/components/navigation/BottomNav.tsx
@@ -9,9 +9,14 @@ interface BottomNavProps {
 
 export default function BottomNav({ loggedIn }: BottomNavProps) {
   
+
+  const items = makeNavItem(navItems, loggedIn).filter(({ href }) =>
+    loggedIn ? href !== '/profile' && href !== '/settings' : true
+  )
+
   return (
       <ul className="flex justify-around py-2">
-        {makeNavItem(navItems, loggedIn).map(({ href, label, icon }) => (
+        {items.map(({ href, label, icon }) => (
           <li key={href}>
             <Link
               to={href}

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { User } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface AvatarProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+  src?: string
+  size?: 'sm' | 'md' | 'lg'
+}
+
+export default function Avatar({ src, size = 'md', className, ...props }: AvatarProps) {
+  const sizes: Record<string, string> = {
+    sm: 'w-8 h-8',
+    md: 'w-10 h-10',
+    lg: 'w-12 h-12',
+  }
+  if (!src) {
+    return <User className={cn(sizes[size], className)} />
+  }
+  return (
+    <img
+      src={src}
+      className={cn('rounded-full object-cover', sizes[size], className)}
+      {...props}
+    />
+  )
+}


### PR DESCRIPTION
## Summary
- add a small `Avatar` component for profile icons
- show avatar link in the top navbar when logged in
- hide profile and settings from the bottom navigation for logged-in users

## Testing
- `npm test`
- `npm run test:e2e` *(fails: missing Playwright browser dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685672198d74832088589d0b980af327