### PR TITLE
Always enable msw

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,0 @@
-PUBLIC_API_MOCKING=enabled

--- a/README.md
+++ b/README.md
@@ -63,16 +63,8 @@
 
 ### Mock API
 개발 편의를 위해 [MSW](https://mswjs.io/) 기반의 목 API가 준비되어 있습니다.
-개발 모드에서는 기본적으로 MSW가 활성화되며, 필요한 경우 아래와 같이 명시적으로 설정할 수 있습니다.
-
-```bash
-# MSW 사용
-PUBLIC_API_MOCKING=enabled npm run dev
-# 실제 API 사용
-PUBLIC_API_MOCKING=disabled npm run dev
-```
-
-프로덕션 빌드에서는 기본적으로 MSW가 비활성화됩니다.
+현재는 별도의 환경 변수 설정 없이도 모든 환경에서 MSW가 기본적으로 활성화되며,
+빌드 후 CSR 환경에서도 목 API가 동작합니다.
 
 로그인은 아래 계정으로 가능합니다.
 
@@ -98,6 +90,5 @@ Fly.io에서 SSR과 MSW를 사용한 MVP를 배포하려면 Fly CLI와 Docker가
    ```bash
    flyctl deploy
    ```
-   배포 환경에서는 `PUBLIC_API_MOCKING=enabled`가 설정되어 있어 MSW가 자동으로 동작합니다.
-   완료 후 출력되는 `https://<app>.fly.dev` 주소로 접속하면 프로덕션 모드에서도 MSW가 실행된 화면을 확인할 수 있습니다.
+  배포 후 출력되는 `https://<app>.fly.dev` 주소로 접속하면 프로덕션 모드에서도 MSW가 실행된 화면을 확인할 수 있습니다.
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -9,9 +9,6 @@ import { createServer as createViteServer, ViteDevServer } from 'vite'
 async function startServer() {
   const app = express()
   const isProd = process.env.NODE_ENV === 'production'
-  const isMocking = process.env.PUBLIC_API_MOCKING
-    ? process.env.PUBLIC_API_MOCKING === 'enabled'
-    : !isProd
   const root = path.resolve(__dirname, '..')
   let vite: ViteDevServer | undefined
 
@@ -28,11 +25,9 @@ async function startServer() {
     app.use('/public', express.static(path.join(root, 'public')))
   }
 
-  if (isMocking) {
-    app.get('/mockServiceWorker.js', (_req, res) => {
-      res.sendFile(path.join(root, 'public/mockServiceWorker.js'))
-    })
-  }
+  app.get('/mockServiceWorker.js', (_req, res) => {
+    res.sendFile(path.join(root, 'public/mockServiceWorker.js'))
+  })
 
   app.use('*', async (req: Request, res: Response) => {
     try {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,14 +5,14 @@ import App from './App';
 import { MetaProvider } from './lib/meta';
 
 async function start() {
-  const env = (import.meta as any).env;
-  const mocking = env.PUBLIC_API_MOCKING ?? (env.DEV ? 'enabled' : 'disabled');
-  if (mocking === 'enabled') {
+  try {
     const { worker } = await import('./mocks/browser');
     await worker.start({
       serviceWorker: { url: '/mockServiceWorker.js' },
       onUnhandledRequest: 'bypass',
     });
+  } catch (err) {
+    console.error('Failed to start MSW', err);
   }
 
   const container = document.getElementById('root')!;


### PR DESCRIPTION
## Summary
- enable MSW in client bundle without env checks
- always expose mock service worker on the dev server
- update README to mention MSW runs by default
- remove obsolete env example file

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68568aaf86a083208bf1a00ac86850e2