### PR TITLE
Implement crew topics and app bar title

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import Navbar from '@/components/Navbar';
+import { AppBarTitleProvider } from '@/lib/appBarTitle';
 import Home from '@/pages/Home';
 import Login from '@/pages/Login';
 import Signup from '@/pages/Signup';
@@ -19,7 +20,7 @@ import Brands from './pages/Brands';
 
 export default function App() {
   return (
-    <>
+    <AppBarTitleProvider>
       <Navbar />
       <main className="pt-4">
         <Routes>
@@ -40,6 +41,6 @@ export default function App() {
           <Route path="/write" element={<Write />} />
         </Routes>
       </main>
-    </>
+    </AppBarTitleProvider>
   );
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -5,9 +5,11 @@ import { getToken, getMyId } from '@/lib/auth';
 import { getProfile } from '@/lib/profile';
 import TopNav from './navigation/TopNav';
 import Avatar from './ui/avatar';
+import { useAppBarTitle } from '@/lib/appBarTitle';
 
 export default function Navbar() {
   const location = useLocation();
+  const title = useAppBarTitle();
   const [loggedIn, setLoggedIn] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
   const [userId, setUserId] = useState<string | null>(null);
@@ -47,11 +49,17 @@ export default function Navbar() {
 
   return (
     <>
-    <nav className="flex items-center justify-between border-b px-4 py-4">
-      <Link to="/" className="font-bold text-xl">
-        Folks
-      </Link>
-      <div className="flex gap-4 items-center">
+    <nav className="relative flex items-center justify-between border-b px-4 py-4">
+      {title ? (
+        <span className="absolute left-1/2 -translate-x-1/2 truncate text-center text-base font-semibold">
+          {title}
+        </span>
+      ) : (
+        <Link to="/" className="font-bold text-xl">
+          Folks
+        </Link>
+      )}
+      <div className="ml-auto flex gap-4 items-center">
         {loggedIn && userId && (
           <Link to={`/profile/${userId}`} aria-label="Profile">
             <Avatar size="sm" src={imageUrl} />

--- a/src/lib/appBarTitle.tsx
+++ b/src/lib/appBarTitle.tsx
@@ -1,0 +1,31 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+interface AppBarTitleContextValue {
+  title: string;
+  setTitle: (t: string) => void;
+}
+
+const AppBarTitleContext = createContext<AppBarTitleContextValue | null>(null);
+
+export function AppBarTitleProvider({ children }: { children: React.ReactNode }) {
+  const [title, setTitle] = useState('');
+  return (
+    <AppBarTitleContext.Provider value={{ title, setTitle }}>
+      {children}
+    </AppBarTitleContext.Provider>
+  );
+}
+
+export function useAppBarTitle() {
+  const ctx = useContext(AppBarTitleContext);
+  return ctx ? ctx.title : '';
+}
+
+export function useSetAppBarTitle(title: string | undefined) {
+  const ctx = useContext(AppBarTitleContext);
+  useEffect(() => {
+    if (!ctx || title === undefined) return;
+    ctx.setTitle(title);
+    return () => ctx.setTitle('');
+  }, [ctx, title]);
+}

--- a/src/lib/crew.ts
+++ b/src/lib/crew.ts
@@ -21,6 +21,11 @@ export interface Notice {
   date: string;
 }
 
+export interface CrewTopic {
+  tag: string;
+  count: number;
+}
+
 export interface Crew {
   id: string;
   name: string;
@@ -63,6 +68,12 @@ export async function fetchCrewEvents(id: string): Promise<Event[]> {
 export async function fetchCrewNotices(id: string): Promise<Notice[]> {
   const res = await fetch(`${API_BASE}/crews/${id}/notices`, { cache: 'no-store' });
   if (!res.ok) throw new Error('Failed to load notices');
+  return res.json();
+}
+
+export async function fetchCrewTopics(id: string): Promise<CrewTopic[]> {
+  const res = await fetch(`${API_BASE}/crews/${id}/topics`, { cache: 'no-store' });
+  if (!res.ok) throw new Error('Failed to load topics');
   return res.json();
 }
 

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -277,6 +277,38 @@ export const handlers = [
     return HttpResponse.json(posts);
   }),
 
+  http.get(`${API_BASE}/crews/:id/events`, ({ params }) => {
+    const { id } = params as { id: string };
+    const events = Array.from({ length: 3 }, (_, i) => ({
+      id: `${id}-${i + 1}`,
+      title: `Event ${i + 1}`,
+      date: new Date().toISOString().slice(0, 10),
+      location: `Location ${i + 1}`,
+      image: `https://picsum.photos/seed/${id}-event-${i}/200/200`,
+    }));
+    return HttpResponse.json(events);
+  }),
+
+  http.get(`${API_BASE}/crews/:id/notices`, ({ params }) => {
+    const { id } = params as { id: string };
+    const notices = Array.from({ length: 2 }, (_, i) => ({
+      id: `${id}-${i + 1}`,
+      title: `Notice ${i + 1}`,
+      content: `Notice content ${i + 1}`,
+      date: new Date().toISOString().slice(0, 10),
+    }));
+    return HttpResponse.json(notices);
+  }),
+
+  http.get(`${API_BASE}/crews/:id/topics`, ({ params }) => {
+    const { id } = params as { id: string };
+    const topics = ['talk', 'column', 'look'].map((tag, idx) => ({
+      tag,
+      count: idx + 1,
+    }));
+    return HttpResponse.json(topics);
+  }),
+
   http.get(`${API_BASE}/brands/:id`, ({ params }) => {
     const { id } = params as { id: string };
     return HttpResponse.json({


### PR DESCRIPTION
## Summary
- add AppBarTitle context for dynamic navbar titles
- show crew name in Navbar when viewing crew page
- update Crew page with Posts/Topics/Events/Notice/Overview tabs
- include mock API handlers for crew events, notices and topics
- wrap App with AppBarTitleProvider

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68569690f15c8320aa2d977ecc17854f