### PR TITLE
Implement crew topics multi-select

### DIFF
--- a/src/lib/crew.ts
+++ b/src/lib/crew.ts
@@ -53,8 +53,14 @@ export async function fetchCrew(id: string): Promise<Crew> {
   return res.json();
 }
 
-export async function fetchCrewPosts(id: string): Promise<Post[]> {
-  const res = await fetch(`${API_BASE}/crews/${id}/posts`, { cache: 'no-store' });
+export async function fetchCrewPosts(
+  id: string,
+  topics: string[] = [],
+): Promise<Post[]> {
+  const search = topics.length ? `?topics=${topics.join(',')}` : '';
+  const res = await fetch(`${API_BASE}/crews/${id}/posts${search}`, {
+    cache: 'no-store',
+  });
   if (!res.ok) throw new Error('Failed to load posts');
   return res.json();
 }


### PR DESCRIPTION
## Summary
- support multi-select topic filters in Crew pages
- keep query params when navigating tabs
- fetch posts with selected topics

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68595845b000832089522660de2df8f8