### PR TITLE
Add navigation from crew events/notice to post page

### DIFF
--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -1,8 +1,13 @@
 import { Event } from '@/lib/crew';
 
-export default function EventCard({ event }: { event: Event }) {
+interface Props {
+  event: Event;
+  onClick?: () => void;
+}
+
+export default function EventCard({ event, onClick }: Props) {
   return (
-    <div className="flex gap-2 rounded border p-2">
+    <div className="flex gap-2 rounded border p-2 cursor-pointer" onClick={onClick}>
       {event.image && (
         <img src={event.image} className="h-20 w-20 rounded object-cover" />
       )}

--- a/src/pages/crew/[id].tsx
+++ b/src/pages/crew/[id].tsx
@@ -172,14 +172,22 @@ export default function CrewDetailPage() {
       {tab === 'events' && (
         <div className="space-y-2">
           {events.map((event) => (
-            <EventCard key={event.id} event={event} />
+            <EventCard
+              key={event.id}
+              event={event}
+              onClick={() => navigate(`/post/${event.id}`)}
+            />
           ))}
         </div>
       )}
       {tab === 'notice' && (
         <ul className="space-y-2">
           {notices.map((n) => (
-            <li key={n.id} className="rounded border p-2">
+            <li
+              key={n.id}
+              className="cursor-pointer rounded border p-2"
+              onClick={() => navigate(`/post/${n.id}`)}
+            >
               <h3 className="font-semibold">{n.title}</h3>
               <p className="text-sm text-gray-500">{n.date}</p>
             </li>


### PR DESCRIPTION
## Summary
- allow `EventCard` to be clickable
- link crew event and notice lists to `/post/:id`

## Testing
- `npm run test`
- `npm run test:e2e` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_6859587dd66883208bbfa4f3d87e3158