### PR TITLE
Improve dark mode

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -19,7 +19,7 @@ export default function Home() {
   const [count, setCount] = useState(0);
 
   return (
-    <main className="min-h-screen bg-white">
+    <main className="min-h-screen bg-background text-foreground">
       <PostGrid />
     </main>
   );

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -54,3 +54,27 @@ placeholder:after {
 button {
   cursor: pointer;
 }
+
+@media (prefers-color-scheme: dark) {
+  .bg-white {
+    background-color: #1a1a1a !important;
+  }
+  .bg-gray-100 {
+    background-color: #222 !important;
+  }
+  .bg-gray-200 {
+    background-color: #333 !important;
+  }
+  .text-gray-500 {
+    color: #aaa !important;
+  }
+  .text-gray-600 {
+    color: #bbb !important;
+  }
+  .text-gray-700 {
+    color: #ccc !important;
+  }
+  .border-gray-300 {
+    border-color: #444 !important;
+  }
+}


### PR DESCRIPTION
## Summary
- tweak global CSS for better dark mode colors
- use background and foreground utility classes in `Home`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859577e53a88320993d79bffb18a098