### PR TITLE
Implement mentions support on write page

### DIFF
--- a/src/components/Editor/core/editor.css
+++ b/src/components/Editor/core/editor.css
@@ -379,3 +379,7 @@ img.ProseMirror-separator {
 .ProseMirror p {
   margin-bottom: 1em;
 }
+
+.mention {
+  color: #2563eb;
+}

--- a/src/components/users/UserMentionList.tsx
+++ b/src/components/users/UserMentionList.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { searchUsers } from '@/lib/user';
+import type { SimpleUser } from '@/lib/profile';
+
+interface Props {
+  query: string;
+  position: { left: number; top: number } | null;
+  onSelect: (user: SimpleUser) => void;
+}
+
+export default function UserMentionList({ query, position, onSelect }: Props) {
+  const [users, setUsers] = useState<SimpleUser[]>([]);
+
+  useEffect(() => {
+    if (!query) {
+      setUsers([]);
+      return;
+    }
+    searchUsers({ search: query, limit: '10' })
+      .then(setUsers)
+      .catch(() => setUsers([]));
+  }, [query]);
+
+  if (!position || users.length === 0) return null;
+
+  return (
+    <ul
+      className="absolute z-50 max-h-60 w-40 overflow-auto rounded border bg-white shadow"
+      style={{ left: position.left, top: position.top }}
+    >
+      {users.map((user) => (
+        <li
+          key={user.userId}
+          className="cursor-pointer px-2 py-1 hover:bg-gray-100"
+          onMouseDown={(e) => {
+            e.preventDefault();
+            onSelect(user);
+          }}
+        >
+          {user.username}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/lib/editorSchema.ts
+++ b/src/lib/editorSchema.ts
@@ -1,4 +1,4 @@
-import { MarkSpec, Schema } from 'prosemirror-model';
+import { MarkSpec, NodeSpec, Schema } from 'prosemirror-model';
 import { schema as basic } from 'prosemirror-schema-basic';
 import { addListNodes } from 'prosemirror-schema-list';
 
@@ -25,6 +25,38 @@ const nodes = baseNodes.update('paragraph', {
     },
   }],
 });
+
+const mentionNode: NodeSpec = {
+  inline: true,
+  group: 'inline',
+  selectable: false,
+  atom: true,
+  attrs: { id: {}, type: {}, label: {} },
+  toDOM(node) {
+    const { id, type, label } = node.attrs as any;
+    return [
+      'span',
+      {
+        'data-id': id,
+        'data-type': type,
+        class: 'mention',
+      },
+      `@${label}`,
+    ];
+  },
+  parseDOM: [
+    {
+      tag: 'span[data-id][data-type]',
+      getAttrs(dom: HTMLElement) {
+        return {
+          id: dom.getAttribute('data-id'),
+          type: dom.getAttribute('data-type'),
+          label: dom.textContent?.replace(/^@/, '') ?? '',
+        };
+      },
+    },
+  ],
+};
 
 const colorMark: MarkSpec = {
   attrs: { color: {} },
@@ -67,7 +99,7 @@ const strikeMark: MarkSpec = {
 };
 
 export const editorSchema = new Schema({
-  nodes,
+  nodes: nodes.addToEnd('mention', mentionNode),
   marks: basic.spec.marks
     .addToEnd('color', colorMark)
     .addToEnd('font', fontMark)

--- a/src/lib/mentions.ts
+++ b/src/lib/mentions.ts
@@ -1,0 +1,22 @@
+export function extractMentionsFromDoc(doc: any): {
+  crewIds: number[];
+  userIds: number[];
+} {
+  const crewIds = new Set<number>();
+  const userIds = new Set<number>();
+
+  const traverse = (node: any) => {
+    if (node.type === 'mention') {
+      const { id, type } = node.attrs || {};
+      if (type === 'crew') crewIds.add(Number(id));
+      if (type === 'user') userIds.add(Number(id));
+    }
+    if (node.content) node.content.forEach(traverse);
+  };
+
+  traverse(doc);
+  return {
+    crewIds: Array.from(crewIds),
+    userIds: Array.from(userIds),
+  };
+}

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -66,3 +66,24 @@ export async function fetchPost(id: number): Promise<Post> {
   }
   return res.json();
 }
+
+export interface CreatePostDto {
+  title: string;
+  type: 'BASIC' | 'COLUMN';
+  content: any;
+  crewMentions: number[];
+  userMentions: number[];
+  metaType?: 'EVENT' | 'NOTICE';
+}
+
+export async function createPost(data: CreatePostDto): Promise<Post> {
+  const res = await fetch(`${API_BASE}/posts`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error('Failed to create post');
+  return res.json();
+}

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -1,0 +1,13 @@
+import { API_BASE } from './auth';
+import type { SimpleUser } from './profile';
+
+export async function searchUsers(
+  params: Record<string, string> = {},
+): Promise<SimpleUser[]> {
+  const search = new URLSearchParams(params).toString();
+  const res = await fetch(`${API_BASE}/users${search ? `?${search}` : ''}`, {
+    cache: 'no-store',
+  });
+  if (!res.ok) throw new Error('Failed to load users');
+  return res.json();
+}

--- a/tests/posts.test.ts
+++ b/tests/posts.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createPost, type CreatePostDto } from '../src/lib/posts';
+import { extractMentionsFromDoc } from '../src/lib/mentions';
+
+declare global {
+  var fetch: any;
+}
+
+describe('posts helpers', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ id: 1 }) });
+  });
+
+  it('createPost sends POST request with JSON body', async () => {
+    const dto: CreatePostDto = {
+      title: 't',
+      type: 'BASIC',
+      content: {},
+      crewMentions: [1],
+      userMentions: [5],
+    };
+    await createPost(dto);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/posts'),
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(dto),
+      }),
+    );
+  });
+
+  it('extractMentionsFromDoc parses ids', () => {
+    const doc = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'mention', attrs: { id: '1', type: 'crew', label: 'c' } },
+            { type: 'text', text: 'hello' },
+            { type: 'mention', attrs: { id: '2', type: 'user', label: 'u' } },
+            { type: 'mention', attrs: { id: '1', type: 'crew', label: 'c' } },
+          ],
+        },
+      ],
+    } as any;
+    const result = extractMentionsFromDoc(doc);
+    expect(result.crewIds).toEqual([1]);
+    expect(result.userIds).toEqual([2]);
+  });
+});


### PR DESCRIPTION
## Summary
- add mention node to editor schema and style
- parse mentions from ProseMirror JSON
- implement `createPost` API and user search helper
- add user mention list component
- enhance write page with metaType field and mention handling
- add unit tests for posts helpers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a4240f3f483208432a6369cdc4a1b