### PR TITLE
Add crew role management modal

### DIFF
--- a/src/components/crews/CrewRoleModal.tsx
+++ b/src/components/crews/CrewRoleModal.tsx
@@ -1,0 +1,136 @@
+import { useState } from 'react';
+import Modal from '../ui/Modal';
+import { Input } from '../ui/input';
+import { Button } from '../ui/button';
+
+interface Role {
+  id: number;
+  name: string;
+  permissions: string[];
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function CrewRoleModal({ open, onClose }: Props) {
+  const [roles, setRoles] = useState<Role[]>([
+    { id: 1, name: 'Owner', permissions: ['manage_member', 'create_notice'] },
+  ]);
+  const [newRoleName, setNewRoleName] = useState('');
+
+  const addRole = () => {
+    if (!newRoleName.trim()) return;
+    setRoles([...roles, { id: Date.now(), name: newRoleName, permissions: [] }]);
+    setNewRoleName('');
+  };
+
+  const updateRoleName = (id: number, name: string) => {
+    setRoles(roles.map((r) => (r.id === id ? { ...r, name } : r)));
+  };
+
+  const removeRole = (id: number) => {
+    setRoles(roles.filter((r) => r.id !== id));
+  };
+
+  const addPermission = (id: number, perm: string) => {
+    if (!perm.trim()) return;
+    setRoles(
+      roles.map((r) =>
+        r.id === id && !r.permissions.includes(perm)
+          ? { ...r, permissions: [...r.permissions, perm] }
+          : r,
+      ),
+    );
+  };
+
+  const removePermission = (id: number, perm: string) => {
+    setRoles(
+      roles.map((r) =>
+        r.id === id
+          ? { ...r, permissions: r.permissions.filter((p) => p !== perm) }
+          : r,
+      ),
+    );
+  };
+
+  return (
+    <Modal open={open} onClose={onClose} className="max-h-[80vh] overflow-y-auto">
+      <div className="space-y-4">
+        <h2 className="text-lg font-semibold">Manage Roles & Permissions</h2>
+        {roles.map((role) => (
+          <div key={role.id} className="rounded border p-2 space-y-2">
+            <div className="flex items-center gap-2">
+              <Input
+                value={role.name}
+                onChange={(e) => updateRoleName(role.id, e.target.value)}
+                className="flex-1"
+              />
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => removeRole(role.id)}
+              >
+                Remove
+              </Button>
+            </div>
+            <ul className="space-y-1 pl-4">
+              {role.permissions.map((perm) => (
+                <li key={perm} className="flex items-center gap-2">
+                  <span className="flex-1 text-sm">{perm}</span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => removePermission(role.id, perm)}
+                  >
+                    Delete
+                  </Button>
+                </li>
+              ))}
+            </ul>
+            <PermissionInput onAdd={(perm) => addPermission(role.id, perm)} />
+          </div>
+        ))}
+        <div className="flex items-center gap-2">
+          <Input
+            placeholder="New role name"
+            value={newRoleName}
+            onChange={(e) => setNewRoleName(e.target.value)}
+          />
+          <Button variant="outline" onClick={addRole}>
+            Add Role
+          </Button>
+        </div>
+        <div className="text-right">
+          <Button onClick={onClose}>Close</Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function PermissionInput({ onAdd }: { onAdd: (perm: string) => void }) {
+  const [value, setValue] = useState('');
+
+  return (
+    <div className="flex items-center gap-2">
+      <Input
+        placeholder="Add permission"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        className="flex-1"
+      />
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => {
+          onAdd(value);
+          setValue('');
+        }}
+      >
+        Add
+      </Button>
+    </div>
+  );
+}

--- a/src/pages/crew/[id].tsx
+++ b/src/pages/crew/[id].tsx
@@ -24,7 +24,8 @@ import EditableText from '@/components/EditableText';
 import EditableImageUpload from '@/components/EditableImageUpload';
 import EditableLinkList from '@/components/EditableLinkList';
 import CrewSettingsModal from '@/components/crews/CrewSettingsModal';
-import { Settings } from 'lucide-react';
+import CrewRoleModal from '@/components/crews/CrewRoleModal';
+import { Settings, UserCog } from 'lucide-react';
 import TabNav from '@/components/TabNav';
 import EventCard from '@/components/EventCard';
 
@@ -116,6 +117,7 @@ export default function CrewDetailPage() {
 
   const isEditable = role === 'owner' || role === 'master';
   const [showSettings, setShowSettings] = useState(false);
+  const [showRoles, setShowRoles] = useState(false);
 
 
   const handleDelete = async () => {
@@ -131,12 +133,14 @@ export default function CrewDetailPage() {
     <div className="relative mx-auto max-w-2xl space-y-4 p-4">
       {isEditable && (
         <>
-          <button
-            className="absolute right-4 top-4"
-            onClick={() => setShowSettings(true)}
-          >
-            <Settings size={20} />
-          </button>
+          <div className="absolute right-4 top-4 flex gap-2">
+            <button onClick={() => setShowRoles(true)}>
+              <UserCog size={20} />
+            </button>
+            <button onClick={() => setShowSettings(true)}>
+              <Settings size={20} />
+            </button>
+          </div>
           <CrewSettingsModal
             open={showSettings}
             crew={crew as Crew}
@@ -148,6 +152,7 @@ export default function CrewDetailPage() {
             }}
             onDelete={handleDelete}
           />
+          <CrewRoleModal open={showRoles} onClose={() => setShowRoles(false)} />
         </>
       )}
       <EditableImageUpload


### PR DESCRIPTION
## Summary
- add a `CrewRoleModal` component for role & permission management
- allow owners/masters to open role management on crew detail page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b68be55f4832095e3e78fcc00359c