### PR TITLE
Implement crew tab settings modal

### DIFF
--- a/src/components/crews/CrewTabSettingsModal.tsx
+++ b/src/components/crews/CrewTabSettingsModal.tsx
@@ -1,0 +1,127 @@
+import { useState } from 'react';
+import Modal from '../ui/Modal';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import type { CrewTab } from '@/lib/crew';
+
+interface Props {
+  open: boolean;
+  tabs: CrewTab[];
+  onSave: (tabs: CrewTab[]) => void;
+  onClose: () => void;
+}
+
+const TAB_OPTIONS = [
+  { value: 'overview', label: 'Overview' },
+  { value: 'posts', label: 'Posts' },
+  { value: 'notice', label: 'Notice' },
+  { value: 'event', label: 'Event' },
+  { value: 'topic', label: 'Topic' },
+];
+
+export default function CrewTabSettingsModal({ open, tabs, onSave, onClose }: Props) {
+  const [localTabs, setLocalTabs] = useState<CrewTab[]>(tabs);
+
+  const handleChange = (index: number, field: keyof CrewTab, value: any) => {
+    setLocalTabs((prev) =>
+      prev.map((t, i) => (i === index ? { ...t, [field]: value } : t)),
+    );
+  };
+
+  const add = () => {
+    const id = Date.now();
+    const order = localTabs.length;
+    setLocalTabs([
+      ...localTabs,
+      { id, crewId: tabs[0]?.crewId ?? 0, title: '', type: 'posts', isVisible: true, order },
+    ]);
+  };
+
+  const remove = (index: number) => {
+    setLocalTabs(localTabs.filter((_, i) => i !== index));
+  };
+
+  const move = (index: number, dir: -1 | 1) => {
+    const newIndex = index + dir;
+    if (newIndex < 0 || newIndex >= localTabs.length) return;
+    const updated = [...localTabs];
+    const tmp = updated[index];
+    updated[index] = updated[newIndex];
+    updated[newIndex] = tmp;
+    updated.forEach((t, i) => (t.order = i));
+    setLocalTabs(updated);
+  };
+
+  const handleSave = () => {
+    const normalized = localTabs.map((t, i) => ({ ...t, order: i }));
+    onSave(normalized);
+  };
+
+  return (
+    <Modal open={open} onClose={onClose} className="max-h-[90vh] overflow-y-auto">
+      <div className="space-y-4">
+        <h2 className="text-lg font-semibold">Manage Tabs</h2>
+        <div className="space-y-3">
+          {localTabs.map((tab, i) => (
+            <div key={tab.id} className="space-y-2 rounded border p-2">
+              <div className="flex items-center gap-2">
+                <Input
+                  value={tab.title}
+                  onChange={(e) => handleChange(i, 'title', e.target.value)}
+                  placeholder="Title"
+                  className="flex-1"
+                />
+                <select
+                  value={tab.type}
+                  onChange={(e) => handleChange(i, 'type', e.target.value)}
+                  className="border rounded px-1 text-sm"
+                >
+                  {TAB_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+                <label className="flex items-center gap-1 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={tab.isVisible}
+                    onChange={(e) => handleChange(i, 'isVisible', e.target.checked)}
+                  />
+                  Visible
+                </label>
+              </div>
+              {tab.type === 'topic' && (
+                <Input
+                  value={tab.hashtag ?? ''}
+                  onChange={(e) => handleChange(i, 'hashtag', e.target.value)}
+                  placeholder="Hashtag"
+                />
+              )}
+              <div className="flex gap-2">
+                <Button variant="outline" size="sm" onClick={() => move(i, -1)}>
+                  Up
+                </Button>
+                <Button variant="outline" size="sm" onClick={() => move(i, 1)}>
+                  Down
+                </Button>
+                <Button variant="outline" size="sm" onClick={() => remove(i)}>
+                  Remove
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+        <Button variant="outline" size="sm" onClick={add}>
+          Add Tab
+        </Button>
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave}>Save</Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/lib/crew.ts
+++ b/src/lib/crew.ts
@@ -26,6 +26,16 @@ export interface CrewTopic {
   count: number;
 }
 
+export interface CrewTab {
+  id: number;
+  crewId: number;
+  title: string;
+  type: string;
+  isVisible: boolean;
+  order: number;
+  hashtag?: string;
+}
+
 export interface Crew {
   id: string;
   name: string;
@@ -81,6 +91,22 @@ export async function fetchCrewNotices(id: string): Promise<Notice[]> {
 export async function fetchCrewTopics(id: string): Promise<CrewTopic[]> {
   const res = await fetch(`${API_BASE}/crews/${id}/topics`, { cache: 'no-store' });
   if (!res.ok) throw new Error('Failed to load topics');
+  return res.json();
+}
+
+export async function fetchCrewTabs(id: string): Promise<CrewTab[]> {
+  const res = await fetch(`${API_BASE}/crews/${id}/tabs`, { cache: 'no-store' });
+  if (!res.ok) throw new Error('Failed to load crew tabs');
+  return res.json();
+}
+
+export async function updateCrewTabs(id: string, tabs: CrewTab[]): Promise<CrewTab[]> {
+  const res = await fetch(`${API_BASE}/crews/${id}/tabs`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(tabs),
+  });
+  if (!res.ok) throw new Error('Failed to update crew tabs');
   return res.json();
 }
 

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -151,6 +151,18 @@ interface Comment {
 
 const commentsMap: Record<string, Comment[]> = {};
 
+interface CrewTab {
+  id: number;
+  crewId: number;
+  title: string;
+  type: string;
+  isVisible: boolean;
+  order: number;
+  hashtag?: string;
+}
+
+const crewTabsMap: Record<string, CrewTab[]> = {};
+
 interface BrandSummary {
   id: string;
   name: string;
@@ -342,6 +354,24 @@ export const handlers = [
       count: idx + 1,
     }));
     return HttpResponse.json(topics);
+  }),
+
+  http.get(`${API_BASE}/crews/:id/tabs`, ({ params }) => {
+    const { id } = params as { id: string };
+    if (!crewTabsMap[id]) {
+      crewTabsMap[id] = [
+        { id: 1, crewId: Number(id), title: 'Posts', type: 'posts', isVisible: true, order: 0 },
+        { id: 2, crewId: Number(id), title: 'Overview', type: 'overview', isVisible: true, order: 1 },
+      ];
+    }
+    return HttpResponse.json(crewTabsMap[id]);
+  }),
+
+  http.put(`${API_BASE}/crews/:id/tabs`, async ({ params, request }) => {
+    const { id } = params as { id: string };
+    const tabs = (await request.json()) as CrewTab[];
+    crewTabsMap[id] = tabs;
+    return HttpResponse.json(crewTabsMap[id]);
   }),
 
   http.post(`${API_BASE}/crews`, async ({ request }) => {

--- a/tests/crew.test.ts
+++ b/tests/crew.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, beforeEach, expect, vi } from 'vitest';
+import { fetchCrewTabs, updateCrewTabs, type CrewTab } from '../src/lib/crew';
+
+declare global {
+  var fetch: any;
+}
+
+describe('crew tab api', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+
+  it('fetchCrewTabs requests tabs', async () => {
+    (global.fetch as any).mockResolvedValue({ ok: true, json: async () => [] });
+    await fetchCrewTabs('1');
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/crews/1/tabs'),
+      expect.objectContaining({ cache: 'no-store' })
+    );
+  });
+
+  it('updateCrewTabs sends PUT with body', async () => {
+    (global.fetch as any).mockResolvedValue({ ok: true, json: async () => [] });
+    const tabs: CrewTab[] = [
+      { id: 1, crewId: 1, title: 'Posts', type: 'posts', isVisible: true, order: 0 },
+    ];
+    await updateCrewTabs('2', tabs);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/crews/2/tabs'),
+      expect.objectContaining({
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(tabs),
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- support CrewTab CRUD API in `lib/crew`
- mock crew tab endpoints
- add `CrewTabSettingsModal` component
- update crew page to use dynamic tabs and modal
- add tests for crew tab API

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b68f236c083209ecc939fb8c8e9ae