### PR TITLE
Support multiple hashtags for topic tabs

### DIFF
--- a/src/components/crews/CrewTabSettingsModal.tsx
+++ b/src/components/crews/CrewTabSettingsModal.tsx
@@ -93,9 +93,18 @@ export default function CrewTabSettingsModal({ open, tabs, onSave, onClose }: Pr
               </div>
               {tab.type === 'topic' && (
                 <Input
-                  value={tab.hashtag ?? ''}
-                  onChange={(e) => handleChange(i, 'hashtag', e.target.value)}
-                  placeholder="Hashtag"
+                  value={tab.hashtags?.join(', ') ?? ''}
+                  onChange={(e) =>
+                    handleChange(
+                      i,
+                      'hashtags',
+                      e.target.value
+                        .split(',')
+                        .map((t) => t.trim())
+                        .filter(Boolean),
+                    )
+                  }
+                  placeholder="Hashtags (comma separated)"
                 />
               )}
               <div className="flex gap-2">

--- a/src/lib/crew.ts
+++ b/src/lib/crew.ts
@@ -33,7 +33,7 @@ export interface CrewTab {
   type: string;
   isVisible: boolean;
   order: number;
-  hashtag?: string;
+  hashtags?: string[];
 }
 
 export interface Crew {

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -158,7 +158,7 @@ interface CrewTab {
   type: string;
   isVisible: boolean;
   order: number;
-  hashtag?: string;
+  hashtags?: string[];
 }
 
 const crewTabsMap: Record<string, CrewTab[]> = {};

--- a/src/pages/crew/[id].tsx
+++ b/src/pages/crew/[id].tsx
@@ -206,7 +206,9 @@ export default function CrewDetailPage() {
       {currentTab?.type === 'topic' && (
         <PostList
           posts={posts.filter((p) =>
-            currentTab?.hashtag ? p.tags?.includes(currentTab.hashtag) : true,
+            currentTab?.hashtags?.length
+              ? currentTab.hashtags.some((tag) => p.tags?.includes(tag))
+              : true,
           )}
         />
       )}


### PR DESCRIPTION
## Summary
- update `CrewTab` interface to hold `hashtags` array
- adjust mocks and pages to use new hashtags array
- allow editing comma-separated hashtags in CrewTabSettingsModal

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685e09e3fe5883209faa854494e72eb6