### PR TITLE
Add follower management modal

### DIFF
--- a/src/components/users/FollowListModal.tsx
+++ b/src/components/users/FollowListModal.tsx
@@ -1,0 +1,53 @@
+import Avatar from '../ui/avatar';
+import Modal from '../ui/Modal';
+import { Button } from '../ui/button';
+import type { SimpleUser } from '@/lib/profile';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  users: SimpleUser[];
+  type: 'followers' | 'following';
+  isMaster?: boolean;
+  onDelete: (id: string) => void;
+  onBlock: (id: string) => void;
+}
+
+export default function FollowListModal({
+  open,
+  onClose,
+  users,
+  type,
+  isMaster = false,
+  onDelete,
+  onBlock,
+}: Props) {
+  return (
+    <Modal open={open} onClose={onClose} className="max-h-[80vh] overflow-y-auto">
+      <div className="space-y-2">
+        <h2 className="text-lg font-semibold capitalize">{type}</h2>
+        <ul className="space-y-2">
+          {users.map((u) => (
+            <li key={u.userId} className="flex items-center gap-2">
+              <Avatar src={u.imageUrl} size="sm" />
+              <span className="flex-1 text-sm">{u.username}</span>
+              {isMaster && (
+                <div className="flex gap-1">
+                  <Button size="sm" variant="outline" onClick={() => onDelete(u.userId)}>
+                    Delete
+                  </Button>
+                  <Button size="sm" variant="outline" onClick={() => onBlock(u.userId)}>
+                    Block
+                  </Button>
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+        <div className="text-right">
+          <Button onClick={onClose}>Close</Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -6,6 +6,7 @@ export interface Profile {
   imageUrl?: string;
   website?: string;
   backgroundUrl?: string;
+  role?: 'member' | 'master' | 'admin';
 }
 
 import { API_BASE, getToken } from './auth';
@@ -169,4 +170,18 @@ export async function getFollowedBrands(userId: string): Promise<Brand[]> {
     throw new Error('Failed to load brands');
   }
   return res.json();
+}
+
+export async function deleteUser(id: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/users/${id}`, { method: 'DELETE' });
+  if (!res.ok) {
+    throw new Error('Failed to delete user');
+  }
+}
+
+export async function blockUser(id: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/users/${id}/block`, { method: 'POST' });
+  if (!res.ok) {
+    throw new Error('Failed to block user');
+  }
 }

--- a/src/pages/profile/[userId].tsx
+++ b/src/pages/profile/[userId].tsx
@@ -3,6 +3,15 @@ import { useEffect, useState } from 'react';
 import PostCard from '@/components/PostCard';
 import TagList from '@/components/TagList';
 import { mockPost, type Post } from '@/lib/posts';
+import FollowListModal from '@/components/users/FollowListModal';
+import {
+  getFollowers,
+  getFollowing,
+  getMyProfile,
+  deleteUser,
+  blockUser,
+  type SimpleUser,
+} from '@/lib/profile';
 
 interface CrewItem {
   id: string;
@@ -16,8 +25,6 @@ interface ProfileData {
   bio: string;
   imageUrl: string;
   tags: string[];
-  following: number;
-  followers: number;
   posts: (Post & { category: 'TALK' | 'COLUMN' | 'CREW' })[];
   crews: CrewItem[];
 }
@@ -43,8 +50,6 @@ function generateMockProfile(userId: string): ProfileData {
     bio: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque imperdiet.',
     imageUrl: `https://picsum.photos/seed/user-${userId}/100`,
     tags,
-    following: 100 + base,
-    followers: 200 + base,
     posts,
     crews,
   };
@@ -56,12 +61,46 @@ export default function UserProfilePage() {
   const userId = params.userId as string;
   const [profile, setProfile] = useState<ProfileData | null>(null);
   const [filter, setFilter] = useState<'ALL' | 'TALK' | 'COLUMN' | 'CREW'>('ALL');
+  const [followers, setFollowers] = useState<SimpleUser[]>([]);
+  const [following, setFollowing] = useState<SimpleUser[]>([]);
+  const [modal, setModal] = useState<'followers' | 'following' | null>(null);
+  const [isMaster, setIsMaster] = useState(false);
 
   useEffect(() => {
-    if (userId) {
-      setProfile(generateMockProfile(userId));
-    }
+    if (!userId) return;
+    setProfile(generateMockProfile(userId));
+    Promise.all([getFollowers(userId), getFollowing(userId), getMyProfile()])
+      .then(([fwr, fwg, me]) => {
+        setFollowers(fwr);
+        setFollowing(fwg);
+        setIsMaster(me.role === 'master' || me.role === 'admin');
+      })
+      .catch(() => {
+        setFollowers([]);
+        setFollowing([]);
+        setIsMaster(false);
+      });
   }, [userId]);
+
+  const handleDelete = async (id: string) => {
+    try {
+      await deleteUser(id);
+      setFollowers((prev) => prev.filter((u) => u.userId !== id));
+      setFollowing((prev) => prev.filter((u) => u.userId !== id));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleBlock = async (id: string) => {
+    try {
+      await blockUser(id);
+      setFollowers((prev) => prev.filter((u) => u.userId !== id));
+      setFollowing((prev) => prev.filter((u) => u.userId !== id));
+    } catch (err) {
+      console.error(err);
+    }
+  };
 
   if (!profile) return <p className="p-4">Loading...</p>;
 
@@ -71,6 +110,7 @@ export default function UserProfilePage() {
       : profile.posts.filter((p) => p.category === filter);
 
   return (
+    <>
     <div className="mx-auto max-w-xl space-y-4 p-4">
       <div className="flex items-center space-x-4">
         <img
@@ -97,18 +137,12 @@ export default function UserProfilePage() {
       </div>
 
       <div className="flex justify-around border-y py-2 text-center text-sm">
-        <div
-          className="cursor-pointer"
-          onClick={() => navigate(`/profile/${userId}/following`)}
-        >
-          <p className="font-semibold">{profile.following}</p>
+        <div className="cursor-pointer" onClick={() => setModal('following')}>
+          <p className="font-semibold">{following.length}</p>
           <p className="text-gray-500">Following</p>
         </div>
-        <div
-          className="cursor-pointer"
-          onClick={() => navigate(`/profile/${userId}/followers`)}
-        >
-          <p className="font-semibold">{profile.followers}</p>
+        <div className="cursor-pointer" onClick={() => setModal('followers')}>
+          <p className="font-semibold">{followers.length}</p>
           <p className="text-gray-500">Followers</p>
         </div>
         <div className="cursor-pointer" onClick={() => window.scrollTo(0, 0)}>
@@ -158,5 +192,24 @@ export default function UserProfilePage() {
         </div>
       </div>
     </div>
+    <FollowListModal
+      open={modal === 'followers'}
+      onClose={() => setModal(null)}
+      users={followers}
+      type="followers"
+      isMaster={isMaster}
+      onDelete={handleDelete}
+      onBlock={handleBlock}
+    />
+    <FollowListModal
+      open={modal === 'following'}
+      onClose={() => setModal(null)}
+      users={following}
+      type="following"
+      isMaster={isMaster}
+      onDelete={handleDelete}
+      onBlock={handleBlock}
+    />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- add modal component to manage follower/following lists
- provide API helpers for deleting and blocking users
- mock API endpoints for follower lists and management in MSW
- integrate modal into user profile page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e241a4aa88320887b0d4d78a32430