### PR TITLE
Add hashtag node to editor

### DIFF
--- a/src/components/Editor/core/editor.css
+++ b/src/components/Editor/core/editor.css
@@ -384,6 +384,10 @@ img.ProseMirror-separator {
   color: #2563eb;
 }
 
+.hashtag {
+  color: #2563eb;
+}
+
 .suggestion-item-container {
   background: white;
   border: 1px solid #e5e7eb;

--- a/src/components/Editor/core/inputrules.ts
+++ b/src/components/Editor/core/inputrules.ts
@@ -1,5 +1,5 @@
 import {inputRules, wrappingInputRule, textblockTypeInputRule,
-        smartQuotes, emDash, ellipsis} from "prosemirror-inputrules"
+        smartQuotes, emDash, ellipsis, InputRule} from "prosemirror-inputrules"
 import {NodeType, Schema} from "prosemirror-model"
 
 /// Given a blockquote node type, returns an input rule that turns `"> "`
@@ -28,6 +28,18 @@ export function codeBlockRule(nodeType: NodeType) {
   return textblockTypeInputRule(/^```$/, nodeType)
 }
 
+export function hashtagRule(nodeType: NodeType) {
+  return new InputRule(/#([\w-]+)\s$/, (state, match, start, end) => {
+    const tag = match[1]
+    if (!tag) return null
+    const { tr } = state
+    const from = end - match[0].length
+    tr.replaceWith(from, end, nodeType.create({ tag }))
+    tr.insertText(' ', from + 1)
+    return tr
+  })
+}
+
 /// Given a node type and a maximum level, creates an input rule that
 /// turns up to that number of `#` characters followed by a space at
 /// the start of a textblock into a heading whose level corresponds to
@@ -46,5 +58,6 @@ export function buildInputRules(schema: Schema) {
   if (type = schema.nodes.bullet_list) rules.push(bulletListRule(type))
   if (type = schema.nodes.code_block) rules.push(codeBlockRule(type))
   if (type = schema.nodes.heading) rules.push(headingRule(type, 6))
+  if (type = schema.nodes.hashtag) rules.push(hashtagRule(type))
   return inputRules({rules})
 }

--- a/src/lib/editorSchema.ts
+++ b/src/lib/editorSchema.ts
@@ -58,6 +58,33 @@ const mentionNode: NodeSpec = {
   ],
 };
 
+const hashtagNode: NodeSpec = {
+  inline: true,
+  group: 'inline',
+  selectable: false,
+  atom: true,
+  attrs: { tag: {} },
+  toDOM(node) {
+    const { tag } = node.attrs as any;
+    return [
+      'span',
+      {
+        'data-tag': tag,
+        class: 'hashtag',
+      },
+      `#${tag}`,
+    ];
+  },
+  parseDOM: [
+    {
+      tag: 'span[data-tag]',
+      getAttrs(dom: HTMLElement) {
+        return { tag: dom.getAttribute('data-tag') };
+      },
+    },
+  ],
+};
+
 const colorMark: MarkSpec = {
   attrs: { color: {} },
   parseDOM: [{
@@ -99,7 +126,9 @@ const strikeMark: MarkSpec = {
 };
 
 export const editorSchema = new Schema({
-  nodes: nodes.addToEnd('mention', mentionNode),
+  nodes: nodes
+    .addToEnd('mention', mentionNode)
+    .addToEnd('hashtag', hashtagNode),
   marks: basic.spec.marks
     .addToEnd('color', colorMark)
     .addToEnd('font', fontMark)

--- a/src/lib/mentions.ts
+++ b/src/lib/mentions.ts
@@ -21,7 +21,8 @@ export const extractFromDoc = (
       if (!isNaN(id)) crewIds.push(id);
     }
     if (types.includes("hashtag") && node.type === "hashtag") {
-      if (node.text) hashtags.push(node.text);
+      const tag = node.attrs?.tag || node.text;
+      if (tag) hashtags.push(tag);
     }
     if (node.content) node.content.forEach(traverse);
   };
@@ -37,4 +38,27 @@ export const extractFromDoc = (
   if (types.includes("crew")) result.crewIds = crewIds;
   if (types.includes("hashtag")) result.hashtags = hashtags;
   return result;
+};
+
+export const extractMentionsFromDoc = (doc: any): {
+  crewIds: number[];
+  userIds: number[];
+} => {
+  const crewIds: number[] = [];
+  const userIds: number[] = [];
+
+  const traverse = (node: any) => {
+    if (node.type === 'mention') {
+      const id = parseInt(node.attrs.id, 10);
+      if (node.attrs.type === 'crew') {
+        if (!isNaN(id) && !crewIds.includes(id)) crewIds.push(id);
+      } else if (node.attrs.type === 'user') {
+        if (!isNaN(id) && !userIds.includes(id)) userIds.push(id);
+      }
+    }
+    if (node.content) node.content.forEach(traverse);
+  };
+
+  traverse(doc);
+  return { crewIds, userIds };
 };


### PR DESCRIPTION
## Summary
- support hashtags in the editor schema
- convert `#tag ` to hashtag nodes via input rule
- style hashtag tokens in editor
- expose mention parsing helpers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685ea1ebfb2883209e6fdeecd4e7f881