### PR TITLE
Add $ brand mention support

### DIFF
--- a/src/components/Editor/core/editor.css
+++ b/src/components/Editor/core/editor.css
@@ -384,6 +384,10 @@ img.ProseMirror-separator {
   color: #2563eb;
 }
 
+.brand {
+  color: #2563eb;
+}
+
 .hashtag {
   color: #2563eb;
 }

--- a/src/components/Editor/core/index.ts
+++ b/src/components/Editor/core/index.ts
@@ -12,6 +12,7 @@ import {buildKeymap} from "./keymap"
 import {buildInputRules} from "./inputrules"
 import { getFolksMentionPlugin } from "@/lib/plugins/mentionPlugin"
 import { searchCrew } from "@/lib/crew"
+import { searchBrand } from "@/lib/brand"
 
 export {buildMenuItems, buildKeymap, buildInputRules}
 
@@ -71,6 +72,24 @@ export function setup(options: {
             type: 'crew',
           }));
           done(crewItems);
+        } catch {
+          done([]);
+        }
+      },
+      getSuggestionsHTML: (items) =>
+        `<div class="suggestion-item-list">${items
+          .map((i) => `<div class="suggestion-item">${i.name}</div>`)
+          .join('')}</div>`,
+    }),
+    getFolksMentionPlugin({
+      mentionTrigger: '$',
+      pluginKey: 'brand-suggestions',
+      nodeType: 'brand',
+      getSuggestions: async (_type, text, done) => {
+        try {
+          const brands = await searchBrand({ search: text, limit: '5' });
+          const brandItems = brands.map((b) => ({ id: b.id, name: b.name }));
+          done(brandItems);
         } catch {
           done([]);
         }

--- a/src/lib/brand.ts
+++ b/src/lib/brand.ts
@@ -42,6 +42,12 @@ export async function fetchBrands(
   return res.json();
 }
 
+export async function searchBrand(
+  params: Record<string, string> = {},
+): Promise<BrandSummary[]> {
+  return fetchBrands(params);
+}
+
 export async function fetchBrandPostPreviews(limit = 6): Promise<Post[]> {
   const search = new URLSearchParams({
     authorType: 'BRAND',

--- a/src/lib/editorSchema.ts
+++ b/src/lib/editorSchema.ts
@@ -58,6 +58,36 @@ const mentionNode: NodeSpec = {
   ],
 };
 
+const brandNode: NodeSpec = {
+  inline: true,
+  group: 'inline',
+  selectable: false,
+  atom: true,
+  attrs: { id: {}, label: {} },
+  toDOM(node) {
+    const { id, label } = node.attrs as any;
+    return [
+      'span',
+      {
+        'data-brand-id': id,
+        class: 'brand',
+      },
+      `$${label}`,
+    ];
+  },
+  parseDOM: [
+    {
+      tag: 'span[data-brand-id]',
+      getAttrs(dom: HTMLElement) {
+        return {
+          id: dom.getAttribute('data-brand-id'),
+          label: dom.textContent?.replace(/^\$/, '') ?? '',
+        };
+      },
+    },
+  ],
+};
+
 const hashtagNode: NodeSpec = {
   inline: true,
   group: 'inline',
@@ -128,6 +158,7 @@ const strikeMark: MarkSpec = {
 export const editorSchema = new Schema({
   nodes: nodes
     .addToEnd('mention', mentionNode)
+    .addToEnd('brand', brandNode)
     .addToEnd('hashtag', hashtagNode),
   marks: basic.spec.marks
     .addToEnd('color', colorMark)

--- a/src/lib/plugins/mentionPlugin.js
+++ b/src/lib/plugins/mentionPlugin.js
@@ -49,7 +49,7 @@ export function getMatch($position, opts) {
   // set type of match
   var type;
   if (mentionMatch) {
-    type = "mention";
+    type = opts.nodeType;
   } else if (tagMatch) {
     type = "tag";
   }
@@ -117,6 +117,8 @@ export function getFolksMentionPlugin(opts) {
   var defaultOpts = {
     mentionTrigger: "@",
     hashtagTrigger: "#",
+    nodeType: "mention",
+    pluginKey: "autosuggestions",
     allowSpace: true,
     getSuggestions: (type, text, cb) => {
       cb([]);
@@ -236,6 +238,11 @@ export function getFolksMentionPlugin(opts) {
         label: item.name,
         type: item.type
       };
+    } else if (state.type === "brand") {
+      attrs = {
+        id: item.id,
+        label: item.name
+      };
     } else {
       attrs = {
         tag: item.tag
@@ -254,7 +261,7 @@ export function getFolksMentionPlugin(opts) {
    * for the plugin properties spec.
    */
   return new Plugin({
-    key: new PluginKey("autosuggestions"),
+    key: new PluginKey(opts.pluginKey),
 
     // we will need state to track if suggestion dropdown is currently active or not
     state: {


### PR DESCRIPTION
## Summary
- extend editor schema with `brand` node
- support brand suggestions triggered by `$`
- make mention plugin generic to allow custom node type and plugin key
- style brand mentions

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ea4c650548320b495c3a930a00612