### PR TITLE
Implement mock HomePage with MSW

### DIFF
--- a/src/components/FeedCard.tsx
+++ b/src/components/FeedCard.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Heart } from "lucide-react";
+
+interface Post {
+  id: string;
+  title: string;
+  imageUrl: string;
+  author: { nickname: string };
+  tags: string[];
+  likeCount: number;
+}
+
+export default function FeedCard({ post }: { post: Post }) {
+  return (
+    <div className="mb-4 w-full">
+      <div className="rounded-2xl overflow-hidden bg-muted">
+        <img src={post.imageUrl} alt={post.title} className="w-full object-cover" />
+      </div>
+      <div className="mt-2 flex flex-wrap gap-1">
+        {post.tags.map((t) => (
+          <span key={t} className="text-xs text-gray-500">#{t}</span>
+        ))}
+      </div>
+      <h3 className="font-semibold mt-1 text-sm">{post.title}</h3>
+      <div className="flex items-center justify-between text-sm text-gray-500 mt-1">
+        <span>{post.author.nickname}</span>
+        <span className="flex items-center gap-1">
+          <Heart size={14} /> {post.likeCount}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/FloatingMenu.tsx
+++ b/src/components/FloatingMenu.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Home, Search, PenLine, Bell, User } from "lucide-react";
+import { Link } from "react-router-dom";
+
+export default function FloatingMenu() {
+  const items = [
+    { href: "/", icon: <Home size={20} />, label: "홈" },
+    { href: "/search", icon: <Search size={20} />, label: "검색" },
+    { href: "/write", icon: <PenLine size={20} />, label: "글쓰기" },
+    { href: "/notifications", icon: <Bell size={20} />, label: "알림" },
+    { href: "/profile", icon: <User size={20} />, label: "마이" },
+  ];
+  return (
+    <nav className="fixed bottom-0 inset-x-0 z-10 pb-[env(safe-area-inset-bottom)]">
+      <ul className="mx-auto mb-2 flex max-w-md items-center justify-around rounded-2xl bg-background/60 backdrop-blur p-2 shadow">
+        {items.map((item) => (
+          <li key={item.href}>
+            <Link to={item.href} aria-label={item.label} className="p-2">{item.icon}</Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/src/components/HashtagChips.tsx
+++ b/src/components/HashtagChips.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+
+interface Tag {
+  name: string;
+  postCount: number;
+}
+
+export default function HashtagChips() {
+  const [tags, setTags] = useState<Tag[]>([]);
+
+  useEffect(() => {
+    fetch("/tags/hot")
+      .then((res) => res.json())
+      .then((data) => setTags(data))
+      .catch(() => setTags([]));
+  }, []);
+
+  return (
+    <div className="flex overflow-x-auto gap-2 pb-1" role="list">
+      {tags.map((tag) => (
+        <span
+          key={tag.name}
+          className={cn(
+            "px-3 py-1 bg-muted rounded-full text-sm whitespace-nowrap cursor-pointer hover:bg-muted/80"
+          )}
+        >
+          #{tag.name}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/components/PostFeedGrid.tsx
+++ b/src/components/PostFeedGrid.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useRef, useState } from "react";
+import FeedCard from "./FeedCard";
+
+interface Post {
+  id: string;
+  title: string;
+  imageUrl: string;
+  author: { nickname: string };
+  tags: string[];
+  likeCount: number;
+}
+
+interface PostResponse {
+  posts: Post[];
+  nextCursor?: string;
+}
+
+export default function PostFeedGrid() {
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [cursor, setCursor] = useState<string | null>("start");
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const loaderRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (cursor === null) return;
+    fetch(`/posts${cursor && cursor !== "start" ? `?cursor=${cursor}` : ""}`)
+      .then((res) => res.json())
+      .then((data: PostResponse) => {
+        setPosts((prev) => [...prev, ...data.posts]);
+        setNextCursor(data.nextCursor ?? null);
+        setCursor(null);
+      })
+      .catch(() => setCursor(null));
+  }, [cursor]);
+
+  useEffect(() => {
+    if (!loaderRef.current) return;
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting && nextCursor) {
+        setCursor(nextCursor);
+      }
+    });
+    observer.observe(loaderRef.current);
+    return () => observer.disconnect();
+  }, [loaderRef, nextCursor]);
+
+  return (
+    <div className="columns-2 gap-4 p-4" role="feed">
+      {posts.map((post) => (
+        <div key={post.id} className="break-inside-avoid">
+          <FeedCard post={post} />
+        </div>
+      ))}
+      {nextCursor && <div ref={loaderRef} className="h-4" />}
+    </div>
+  );
+}

--- a/src/components/TopAppBar.tsx
+++ b/src/components/TopAppBar.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { Menu } from "lucide-react";
+import Avatar from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+
+interface User {
+  id: string;
+  nickname: string;
+  avatarUrl: string;
+}
+
+export default function TopAppBar() {
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    fetch("/users/me")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => setUser(data))
+      .catch(() => setUser(null));
+  }, []);
+
+  return (
+    <header className="flex items-center justify-between px-4 py-3 border-b bg-background/80 backdrop-blur sticky top-0 z-10">
+      <Link to="/" className="font-bold text-lg">
+        Folks
+      </Link>
+      {user ? (
+        <div className="flex items-center gap-2">
+          <Avatar src={user.avatarUrl} size="sm" />
+          <button aria-label="menu">
+            <Menu size={20} />
+          </button>
+        </div>
+      ) : (
+        <Button asChild size="sm" variant="outline">
+          <Link to="/login">로그인</Link>
+        </Button>
+      )}
+    </header>
+  );
+}

--- a/src/mocks/server.ts
+++ b/src/mocks/server.ts
@@ -1,0 +1,4 @@
+import { setupServer } from 'msw/node';
+import { handlers } from './handlers';
+
+export const server = setupServer(...handlers);

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import TopAppBar from "@/components/TopAppBar";
+import HashtagChips from "@/components/HashtagChips";
+import PostFeedGrid from "@/components/PostFeedGrid";
+import FloatingMenu from "@/components/FloatingMenu";
+
+export default function HomePage() {
+  return (
+    <div className="min-h-screen pb-16 bg-background text-foreground">
+      <TopAppBar />
+      <section className="px-4 py-2">
+        <HashtagChips />
+      </section>
+      <PostFeedGrid />
+      <FloatingMenu />
+    </div>
+  );
+}

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,6 @@
+import { afterAll, afterEach, beforeAll } from 'vitest';
+import { server } from './mocks/server';
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    setupFiles: ['./src/setupTests.ts'],
     include: ['tests/**/*.test.ts'],
     exclude: ['tests/e2e/**'],
   },


### PR DESCRIPTION
## Summary
- add HomePage and supporting UI components
- set up MSW handlers, server, and test configuration for the new APIs
- include floating bottom menu and masonry-style feed grid

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6865e0e2275c83209a6ecc94eaf8d330