### PR TITLE
Add new HomePage UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import Navbar from '@/components/Navbar';
 import { AppBarTitleProvider } from '@/lib/appBarTitle';
-import Home from '@/pages/Home';
+import HomePage from '@/pages/HomePage';
 import Login from '@/pages/Login';
 import Signup from '@/pages/Signup';
 import Posts from '@/pages/Posts';
@@ -25,7 +25,7 @@ export default function App() {
       <Navbar />
       <main className="pt-4">
         <Routes>
-          <Route path="/" element={<Home />} />
+          <Route path="/" element={<HomePage />} />
           <Route path="/login" element={<Login />} />
           <Route path="/signup" element={<Signup />} />
           <Route path="/post/:postId" element={<Post />} />

--- a/src/components/FeedCard.tsx
+++ b/src/components/FeedCard.tsx
@@ -12,17 +12,16 @@ interface Post {
 
 export default function FeedCard({ post }: { post: Post }) {
   return (
-    <div className="mb-4 w-full">
-      <div className="rounded-2xl overflow-hidden bg-muted">
-        <img src={post.imageUrl} alt={post.title} className="w-full object-cover" />
+    <div className="mb-3 w-full">
+      <div className="overflow-hidden rounded-lg bg-muted aspect-[4/5]">
+        <img
+          src={post.imageUrl}
+          alt={post.title}
+          className="h-full w-full object-cover"
+        />
       </div>
-      <div className="mt-2 flex flex-wrap gap-1">
-        {post.tags.map((t) => (
-          <span key={t} className="text-xs text-gray-500">#{t}</span>
-        ))}
-      </div>
-      <h3 className="font-semibold mt-1 text-sm">{post.title}</h3>
-      <div className="flex items-center justify-between text-sm text-gray-500 mt-1">
+      <h3 className="mt-2 text-sm font-semibold">{post.title}</h3>
+      <div className="mt-1 flex items-center justify-between text-sm opacity-80">
         <span>{post.author.nickname}</span>
         <span className="flex items-center gap-1">
           <Heart size={14} /> {post.likeCount}

--- a/src/components/FloatingMenu.tsx
+++ b/src/components/FloatingMenu.tsx
@@ -11,11 +11,17 @@ export default function FloatingMenu() {
     { href: "/profile", icon: <User size={20} />, label: "마이" },
   ];
   return (
-    <nav className="fixed bottom-0 inset-x-0 z-10 pb-[env(safe-area-inset-bottom)]">
-      <ul className="mx-auto mb-2 flex max-w-md items-center justify-around rounded-2xl bg-background/60 backdrop-blur p-2 shadow">
-        {items.map((item) => (
-          <li key={item.href}>
-            <Link to={item.href} aria-label={item.label} className="p-2">{item.icon}</Link>
+    <nav className="pointer-events-none fixed inset-x-0 bottom-4 z-10">
+      <ul className="mx-auto flex h-[64px] w-[85%] items-center justify-around rounded-full bg-white/30 p-2 backdrop-blur-md shadow-md">
+        {items.map((item, idx) => (
+          <li key={item.href} className={idx === 2 ? 'translate-y-[-12px]' : ''}>
+            <Link
+              to={item.href}
+              aria-label={item.label}
+              className="pointer-events-auto flex h-10 w-10 items-center justify-center rounded-full"
+            >
+              {item.icon}
+            </Link>
           </li>
         ))}
       </ul>

--- a/src/components/HashtagChips.tsx
+++ b/src/components/HashtagChips.tsx
@@ -17,17 +17,24 @@ export default function HashtagChips() {
   }, []);
 
   return (
-    <div className="flex overflow-x-auto gap-2 pb-1" role="list">
-      {tags.map((tag) => (
-        <span
-          key={tag.name}
-          className={cn(
-            "px-3 py-1 bg-muted rounded-full text-sm whitespace-nowrap cursor-pointer hover:bg-muted/80"
-          )}
-        >
-          #{tag.name}
-        </span>
-      ))}
+    <div>
+      <h2 className="pb-2 pt-1 text-sm font-bold">HOT Hashtags</h2>
+      <div
+        className="flex gap-2 overflow-x-auto whitespace-nowrap scroll-snap-x pb-1"
+        role="list"
+      >
+        {tags.map((tag) => (
+          <button
+            key={tag.name}
+            onClick={() => {}}
+            className={cn(
+              "rounded-full bg-[#F7F7F7] px-3 py-1 text-sm hover:bg-black hover:text-white transition"
+            )}
+          >
+            #{tag.name} ({tag.postCount})
+          </button>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/HomeCrewGrid.tsx
+++ b/src/components/HomeCrewGrid.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from "react";
+import ImageWithSkeleton from "@/components/ImageWithSkeleton";
+import type { CrewSummary } from "@/lib/crew";
+
+export default function HomeCrewGrid() {
+  const [crews, setCrews] = useState<CrewSummary[]>([]);
+
+  useEffect(() => {
+    fetch("/crews?sort=popular")
+      .then((res) => res.json())
+      .then((data: CrewSummary[]) => setCrews(data.slice(0, 3)))
+      .catch(() => setCrews([]));
+  }, []);
+
+  return (
+    <section className="mt-5 px-4">
+      <h2 className="mb-3 text-md font-bold">Crews</h2>
+      <div className="grid grid-cols-3 gap-3">
+        {crews.map((crew) => (
+          <div
+            key={crew.id}
+            onClick={() => {}}
+            className="relative cursor-pointer"
+          >
+            <ImageWithSkeleton
+              src={crew.coverImage}
+              alt={crew.name}
+              className="aspect-square rounded-lg"
+              skeletonClassName="rounded-lg"
+            />
+            <div className="absolute inset-0 rounded-lg bg-gradient-to-t from-black/80 to-transparent" />
+            <div className="absolute bottom-1 left-1 right-1 text-white">
+              <div className="text-sm font-bold leading-none">{crew.name}</div>
+              <div className="text-xs">{crew.memberCount.toLocaleString()} members</div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/PostFeedGrid.tsx
+++ b/src/components/PostFeedGrid.tsx
@@ -45,7 +45,7 @@ export default function PostFeedGrid() {
   }, [loaderRef, nextCursor]);
 
   return (
-    <div className="columns-2 gap-4 p-4" role="feed">
+    <div className="columns-2 gap-3 p-4" role="feed">
       {posts.map((post) => (
         <div key={post.id} className="break-inside-avoid">
           <FeedCard post={post} />

--- a/src/components/TopAppBar.tsx
+++ b/src/components/TopAppBar.tsx
@@ -21,13 +21,11 @@ export default function TopAppBar() {
   }, []);
 
   return (
-    <header className="flex items-center justify-between px-4 py-3 border-b bg-background/80 backdrop-blur sticky top-0 z-10">
-      <Link to="/" className="font-bold text-lg">
-        Folks
-      </Link>
+    <header className="sticky top-0 z-10 flex items-center justify-between bg-white px-4 py-2">
+      <span className="text-xl font-bold">Folks</span>
       {user ? (
         <div className="flex items-center gap-2">
-          <Avatar src={user.avatarUrl} size="sm" />
+          <Avatar src={user.avatarUrl} className="h-9 w-9" />
           <button aria-label="menu">
             <Menu size={20} />
           </button>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -3,6 +3,7 @@ import TopAppBar from "@/components/TopAppBar";
 import HashtagChips from "@/components/HashtagChips";
 import PostFeedGrid from "@/components/PostFeedGrid";
 import FloatingMenu from "@/components/FloatingMenu";
+import HomeCrewGrid from "@/components/HomeCrewGrid";
 
 export default function HomePage() {
   return (
@@ -11,6 +12,7 @@ export default function HomePage() {
       <section className="px-4 py-2">
         <HashtagChips />
       </section>
+      <HomeCrewGrid />
       <PostFeedGrid />
       <FloatingMenu />
     </div>


### PR DESCRIPTION
## Summary
- redesign TopAppBar and chips list
- add home crew grid section
- tweak feed cards and masonry grid
- update floating bottom menu
- make HomePage the root page

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6865e2c7c95c83208b49f75266f36fae