### PR TITLE
Add comment and like features

### DIFF
--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,21 @@
+import { forwardRef, ComponentPropsWithoutRef } from 'react';
+import { cn } from '../../lib/utils';
+
+export type TextareaProps = ComponentPropsWithoutRef<'textarea'>;
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        ref={ref}
+        className={cn(
+          'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+Textarea.displayName = 'Textarea';
+

--- a/src/lib/postDetail.ts
+++ b/src/lib/postDetail.ts
@@ -30,3 +30,26 @@ export async function fetchPostComments(id: string): Promise<PostComment[]> {
   if (!res.ok) throw new Error('Failed to load comments');
   return res.json();
 }
+
+export async function addPostComment(
+  id: string,
+  content: string,
+): Promise<PostComment> {
+  const res = await fetch(`${API_BASE}/posts/${id}/comments`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
+  });
+  if (!res.ok) throw new Error('Failed to add comment');
+  return res.json();
+}
+
+export async function likePost(id: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/posts/${id}/like`, { method: 'POST' });
+  if (!res.ok) throw new Error('Failed to like post');
+}
+
+export async function unlikePost(id: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/posts/${id}/unlike`, { method: 'DELETE' });
+  if (!res.ok) throw new Error('Failed to unlike post');
+}

--- a/tests/postDetail.test.ts
+++ b/tests/postDetail.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, beforeEach, expect, vi } from 'vitest';
-import { fetchPostDetail, fetchPostComments } from '../src/lib/postDetail';
+import {
+  fetchPostDetail,
+  fetchPostComments,
+  addPostComment,
+  likePost,
+  unlikePost,
+} from '../src/lib/postDetail';
 
 declare global {
   var fetch: any;
@@ -23,6 +29,34 @@ describe('post detail api', () => {
     expect(global.fetch).toHaveBeenCalledWith(
       expect.stringContaining('/posts/abc123/comments'),
       expect.objectContaining({ cache: 'no-store' })
+    );
+  });
+
+  it('addPostComment posts comment', async () => {
+    await addPostComment('1', 'hi');
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/posts/1/comments'),
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: 'hi' }),
+      })
+    );
+  });
+
+  it('likePost sends POST request', async () => {
+    await likePost('1');
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/posts/1/like'),
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('unlikePost sends DELETE request', async () => {
+    await unlikePost('1');
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/posts/1/unlike'),
+      expect.objectContaining({ method: 'DELETE' })
     );
   });
 });


### PR DESCRIPTION
## Summary
- support adding comments and toggling likes on `PostDetailPage`
- expose new helper functions `addPostComment`, `likePost`, and `unlikePost`
- create `Textarea` UI component
- update mock handlers for new APIs
- expand post detail tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865f214831c83209a3bd3c4b20aa084