### PR TITLE
Add signup page with form validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,9 @@
         "prosemirror-state": "^1.4.3",
         "prosemirror-view": "^1.40.0",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "react-hook-form": "^7.59.0",
+        "react-hot-toast": "^2.5.2"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -3468,7 +3470,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -4793,6 +4794,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/gopd": {
@@ -6996,6 +7006,39 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.59.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.59.0.tgz",
+      "integrity": "sha512-kmkek2/8grqarTJExFNjy+RXDIP8yM+QTl3QL6m6Q8b2bih4ltmiXxH7T9n+yXNK477xPh5yZT/6vD8sYGzJTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.5.2.tgz",
+      "integrity": "sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "prosemirror-state": "^1.4.3",
     "prosemirror-view": "^1.40.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-hook-form": "^7.59.0",
+    "react-hot-toast": "^2.5.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -329,10 +329,17 @@ export const handlers = [
     );
   }),
 
-  http.post(`${API_BASE}/auth/signup`, async () => {
+  http.post(`${API_BASE}/auth/signup`, async ({ request }) => {
+    const { email, password, nickname } = await request.json();
+    if (email && password && nickname) {
+      return HttpResponse.json(
+        { user: { id: "user-123", nickname } },
+        { status: 200 }
+      );
+    }
     return HttpResponse.json(
-      { accessToken: "mock-token", userId: currentProfile.userId },
-      { status: 200 }
+      { message: "Missing required fields" },
+      { status: 400 }
     );
   }),
 

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,87 +1,146 @@
-import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { signup } from '@/lib/auth';
+import { useForm } from 'react-hook-form';
+import { Toaster, toast } from 'react-hot-toast';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
 import { useMeta } from '@/lib/meta';
+import { API_BASE } from '@/lib/auth';
+
+interface FormValues {
+  email: string;
+  password: string;
+  nickname: string;
+  profileImage?: string;
+  intro?: string;
+  isAgreeTerms: boolean;
+  isAgreePrivacy: boolean;
+}
 
 export default function SignupPage() {
   const navigate = useNavigate();
   useMeta({ title: 'Sign Up - Stylefolks' });
-  const [email, setEmail] = useState('');
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
-  const [error, setError] = useState('');
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    formState: { errors, isValid },
+  } = useForm<FormValues>({ mode: 'onChange' });
+  const profilePreview = watch('profileImage');
+  const agreeTerms = watch('isAgreeTerms');
+  const agreePrivacy = watch('isAgreePrivacy');
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const onSubmit = async (data: FormValues) => {
     try {
-      await signup(email, username, password);
-      navigate('/');
+      const { isAgreeTerms, isAgreePrivacy, ...payload } = data;
+      const res = await fetch(`${API_BASE}/auth/signup`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.message || 'Sign up failed');
+      }
+      navigate('/login');
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Sign up failed';
-      setError(message);
+      toast.error(message);
     }
   };
 
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) {
+      setValue('profileImage', undefined);
+      return;
+    }
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      setValue('profileImage', reader.result as string, { shouldValidate: false });
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const canSubmit = isValid && agreeTerms && agreePrivacy;
+
   return (
     <div className="flex justify-center">
-      <div className="w-full max-w-md p-10 space-y-6">
-        <h1 className="text-2xl font-bold text-center">Create Your Account</h1>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-1">
-            <label htmlFor="email" className="block text-sm font-medium">
-              Email
+      <div className="w-full max-w-md p-10 space-y-4">
+        <div className="my-6 text-center space-y-1">
+          <h1 className="text-4xl font-bold">Folks</h1>
+          <p className="text-sm text-gray-400">Make culture</p>
+        </div>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <Input
+            placeholder="Email address"
+            type="email"
+            className={cn('rounded-md border py-2 px-3 w-full', errors.email && 'border-red-500')}
+            {...register('email', { required: true, pattern: /.+@.+\..+/ })}
+          />
+          <Input
+            placeholder="Password"
+            type="password"
+            className={cn('rounded-md border py-2 px-3 w-full', errors.password && 'border-red-500')}
+            {...register('password', { required: true, minLength: 6 })}
+          />
+          <Input
+            placeholder="Nickname"
+            className={cn('rounded-md border py-2 px-3 w-full', errors.nickname && 'border-red-500')}
+            {...register('nickname', { required: true, minLength: 2, maxLength: 20 })}
+          />
+          <div>
+            <label className="block text-sm mb-1">Profile image (optional)</label>
+            <label className="w-12 h-12 border rounded-md flex justify-center items-center text-sm cursor-pointer">
+              {profilePreview ? (
+                <img src={profilePreview} className="w-12 h-12 object-cover rounded-md" />
+              ) : (
+                'Upload'
+              )}
+              <input type="file" accept="image/*" className="hidden" onChange={handleImageChange} />
             </label>
-            <Input
-              id="email"
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-            />
           </div>
-          <div className="space-y-1">
-            <label htmlFor="username" className="block text-sm font-medium">
-              Username
-            </label>
-            <Input
-              id="username"
-              type="text"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              required
-            />
-          </div>
-          <div className="space-y-1">
-            <label htmlFor="password" className="block text-sm font-medium">
-              Password
-            </label>
-            <Input
-              id="password"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-            />
-          </div>
-          {error && <p className="text-red-500 text-sm">{error}</p>}
-          <Button type="submit" className="w-full">
+          <Textarea
+            placeholder="One-line introduction"
+            className={cn('rounded-md border py-2 px-3 w-full', errors.intro && 'border-red-500')}
+            {...register('intro', { maxLength: 100 })}
+          />
+          <label className="flex items-center gap-2 text-sm mb-2">
+            <input type="checkbox" {...register('isAgreeTerms', { required: true })} />
+            <span>
+              Agree to Terms of Service{' '}
+              <Link to="#" className="underline text-gray-400">
+                View details
+              </Link>
+            </span>
+          </label>
+          <label className="flex items-center gap-2 text-sm mb-2">
+            <input type="checkbox" {...register('isAgreePrivacy', { required: true })} />
+            <span>
+              Agree to Privacy Policy{' '}
+              <Link to="#" className="underline text-gray-400">
+                View details
+              </Link>
+            </span>
+          </label>
+          <Button
+            type="submit"
+            disabled={!canSubmit}
+            className="bg-black text-white py-2 w-full rounded-xl disabled:opacity-30"
+          >
             Sign Up
           </Button>
         </form>
-        <div className="flex items-center gap-2 text-sm text-gray-500">
-          <span className="h-px flex-1 bg-gray-300" />
-          OR
-          <span className="h-px flex-1 bg-gray-300" />
-        </div>
         <p className="text-center text-sm">
-          {"Already have an account?"}{' '}
+          Already have an account?{' '}
           <Link to="/login" className="underline">
             Login
           </Link>
         </p>
       </div>
+      <Toaster position="top-right" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- install react-hook-form and react-hot-toast
- implement new Signup page using React Hook Form
- add MSW handler for `POST /auth/signup`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6866039a5b7c8320ab3f470f93aa8170