### PR TITLE
Fix search param handling and types

### DIFF
--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -123,4 +123,4 @@ export async function savePostDraft(data: CreatePostDto): Promise<{ success: boo
 const TYPES = ["BASIC", "COLUMN"] as const;
 export const SEARCH_POST_TYPES = ["ALL", ...TYPES] as const;
 export type PostType = (typeof TYPES)[number];
-export type SearchPostType = "TALK" | "COLUMN" | "ALL";
+export type SearchPostType = "BASIC" | "COLUMN" | "ALL";

--- a/src/lib/searchParams.ts
+++ b/src/lib/searchParams.ts
@@ -1,0 +1,24 @@
+import type { SearchPostType } from './posts';
+
+export interface SearchOptions {
+  query?: string;
+  tags?: string[];
+  type?: SearchPostType;
+}
+
+export function buildSearchParams({ query, tags, type }: SearchOptions): URLSearchParams {
+  const params = new URLSearchParams();
+  if (query) params.set('query', query);
+  if (tags && tags.length) params.set('tag', tags.join(','));
+  if (type && type !== 'ALL') params.set('type', type);
+  return params;
+}
+
+export function parseSearchParams(search: string | URLSearchParams): SearchOptions {
+  const params = typeof search === 'string' ? new URLSearchParams(search) : search;
+  const query = params.get('query') ?? undefined;
+  const tag = params.get('tag');
+  const tags = tag ? tag.split(',').filter(Boolean) : [];
+  const type = (params.get('type') as SearchPostType) ?? 'ALL';
+  return { query, tags, type };
+}

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -1,12 +1,13 @@
 import { useState, useEffect, useCallback } from "react";
-import { useLocation } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import SearchInput from "@/components/search/SearchInput";
 import PostTypeTabs from "@/components/search/PostTypeTabs";
 import TagFilterChips from "@/components/search/TagFilterChips";
 import EmptyState from "@/components/search/EmptyState";
 import PostCard from "@/components/PostCard";
 import useInfiniteScroll from "@/components/useInfiniteScroll";
-import { getNextPosts, PostType, SearchPostType, type Post } from "@/lib/posts";
+import { getNextPosts, SearchPostType, type Post } from "@/lib/posts";
+import { buildSearchParams, parseSearchParams } from "@/lib/searchParams";
 import { useMeta } from "@/lib/meta";
 import { TAGS } from "@/mocks/tags";
 
@@ -14,7 +15,7 @@ const PAGE_SIZE = 10;
 
 function filterByType(post: Post, type: SearchPostType) {
   switch (type) {
-    case "TALK":
+    case "BASIC":
       return post.type === "BASIC";
     case "COLUMN":
       return post.type === "COLUMN";
@@ -25,10 +26,11 @@ function filterByType(post: Post, type: SearchPostType) {
 
 export default function SearchPage() {
   useMeta({ title: "Search - Stylefolks" });
-  const location = useLocation();
-  const [query, setQuery] = useState("");
-  const [type, setType] = useState<SearchPostType>("ALL");
-  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const initial = parseSearchParams(searchParams);
+  const [query, setQuery] = useState(initial.query ?? "");
+  const [type, setType] = useState<SearchPostType>(initial.type ?? "ALL");
+  const [selectedTags, setSelectedTags] = useState<string[]>(initial.tags ?? []);
   const [posts, setPosts] = useState<Post[]>([]);
   const [nextId, setNextId] = useState(0);
 
@@ -60,12 +62,16 @@ export default function SearchPage() {
   }, [query, selectedTags, type, applyFilters]);
 
   useEffect(() => {
-    const params = new URLSearchParams(location.search);
-    const tag = params.get("tag");
-    if (tag) {
-      setSelectedTags([tag]);
-    }
-  }, [location.search]);
+    const parsed = parseSearchParams(searchParams);
+    setQuery(parsed.query ?? "");
+    setSelectedTags(parsed.tags ?? []);
+    setType(parsed.type ?? "ALL");
+  }, [searchParams]);
+
+  useEffect(() => {
+    const params = buildSearchParams({ query, tags: selectedTags, type });
+    setSearchParams(params);
+  }, [query, selectedTags, type, setSearchParams]);
 
   return (
     <div className="p-4 space-y-4">

--- a/tests/searchParams.test.ts
+++ b/tests/searchParams.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { buildSearchParams, parseSearchParams } from '../src/lib/searchParams';
+
+describe('search params utils', () => {
+  it('builds comma separated tags', () => {
+    const params = buildSearchParams({ tags: ['a', 'b'] });
+    expect(params.get('tag')).toBe('a,b');
+  });
+
+  it('omits query and type when not provided or ALL', () => {
+    const params = buildSearchParams({ query: '', type: 'ALL', tags: [] });
+    expect(params.toString()).toBe('');
+  });
+
+  it('includes query and type', () => {
+    const params = buildSearchParams({ query: 'hello', tags: ['t'], type: 'COLUMN' });
+    expect(params.get('query')).toBe('hello');
+    expect(params.get('tag')).toBe('t');
+    expect(params.get('type')).toBe('COLUMN');
+  });
+
+  it('parses values back', () => {
+    const opts = parseSearchParams('query=x&tag=a,b&type=BASIC');
+    expect(opts.query).toBe('x');
+    expect(opts.tags).toEqual(['a', 'b']);
+    expect(opts.type).toBe('BASIC');
+  });
+});


### PR DESCRIPTION
## Summary
- unify post type names with `BASIC`/`COLUMN`/`ALL`
- centralize `SearchPostType` definition in `posts` module
- adjust search filter logic to use the unified type

## Testing
- `npm run build`
- `npm test`
- `npm run dev` *(started and exited)*

------
https://chatgpt.com/codex/tasks/task_e_68671e616ee0832080c0dc4e4d866402