### PR TITLE
Add crew settings page with member and tab management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import ResetPasswordPage from '@/pages/ResetPassword';
 import Post from '@/pages/Post';
 import PostDetailPage from '@/pages/PostDetailPage';
 import CrewDetailPage from '@/pages/CrewDetailPage';
+import CrewSettingsPage from '@/pages/CrewSettingsPage';
 import CrewDirectoryPage from '@/pages/CrewDirectoryPage';
 import CreateCrewPage from '@/pages/CreateCrew';
 import UserProfilePage from '@/pages/profile/[userId]';
@@ -33,6 +34,7 @@ export default function App() {
           <Route path="/crews" element={<CrewDirectoryPage />} />
           <Route path="/search" element={<Search />} />
           <Route path="/crew/:id" element={<CrewDetailPage />} />
+          <Route path="/crew/:crewId/settings" element={<CrewSettingsPage />} />
           <Route path="/posts/:id" element={<PostDetailPage />} />
           <Route path="/profile/:userId" element={<UserProfilePage />} />
           <Route path="/write" element={<CreatePostPage />} />

--- a/src/lib/crew.ts
+++ b/src/lib/crew.ts
@@ -168,6 +168,38 @@ export async function fetchMyCrewRole(id: string): Promise<CrewRole> {
   return data.role as CrewRole;
 }
 
+export interface CrewMember {
+  userId: string;
+  nickname: string;
+  role: CrewRole;
+}
+
+export async function fetchCrewMembers(id: string): Promise<CrewMember[]> {
+  const res = await fetch(`${API_BASE}/crews/${id}/members`, { cache: 'no-store' });
+  if (!res.ok) throw new Error('Failed to load members');
+  return res.json();
+}
+
+export async function updateCrewMemberRole(
+  crewId: string,
+  userId: string,
+  role: CrewRole,
+): Promise<void> {
+  const res = await fetch(`${API_BASE}/crews/${crewId}/members/${userId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ role }),
+  });
+  if (!res.ok) throw new Error('Failed to update role');
+}
+
+export async function removeCrewMember(crewId: string, userId: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/crews/${crewId}/members/${userId}`, {
+    method: 'DELETE',
+  });
+  if (!res.ok) throw new Error('Failed to remove member');
+}
+
 export async function deleteCrew(id: string): Promise<void> {
   const token = getToken();
   const res = await fetch(`${API_BASE}/crews/${id}`, {

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -330,6 +330,13 @@ interface CrewTab {
 }
 
 const crewTabsMap: Record<string, CrewTab[]> = {};
+interface CrewMember {
+  userId: string;
+  nickname: string;
+  role: 'owner' | 'manager' | 'member';
+}
+
+const crewMembersMap: Record<string, CrewMember[]> = {};
 
 interface BrandSummary {
   id: string;
@@ -675,6 +682,33 @@ export const handlers = [
       ];
     }
     return HttpResponse.json(crewTabsMap[id]);
+  }),
+
+  http.get(`${API_BASE}/crews/:id/members`, ({ params }) => {
+    const { id } = params as { id: string };
+    if (!crewMembersMap[id]) {
+      crewMembersMap[id] = [
+        { userId: 'u1', nickname: 'owner', role: 'owner' },
+        { userId: 'u2', nickname: 'manager1', role: 'manager' },
+        { userId: 'u3', nickname: 'member1', role: 'member' },
+      ];
+    }
+    return HttpResponse.json(crewMembersMap[id]);
+  }),
+
+  http.patch(`${API_BASE}/crews/:id/members/:userId`, async ({ params, request }) => {
+    const { id, userId } = params as { id: string; userId: string };
+    const { role } = await request.json();
+    crewMembersMap[id] = crewMembersMap[id].map((m) =>
+      m.userId === userId ? { ...m, role } : m,
+    );
+    return HttpResponse.json({});
+  }),
+
+  http.delete(`${API_BASE}/crews/:id/members/:userId`, ({ params }) => {
+    const { id, userId } = params as { id: string; userId: string };
+    crewMembersMap[id] = crewMembersMap[id].filter((m) => m.userId !== userId);
+    return new HttpResponse(null, { status: 204 });
   }),
 
   http.put(`${API_BASE}/crews/:id/tabs`, async ({ params, request }) => {

--- a/src/pages/CrewSettingsPage.tsx
+++ b/src/pages/CrewSettingsPage.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useMeta } from '@/lib/meta';
+import {
+  CrewTab,
+  fetchCrewTabs,
+  updateCrewTabs,
+  CrewMember,
+  fetchCrewMembers,
+  updateCrewMemberRole,
+  removeCrewMember,
+  CrewRole,
+} from '@/lib/crew';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import Badge from '@/components/ui/badge';
+
+export default function CrewSettingsPage() {
+  const { crewId } = useParams<{ crewId: string }>();
+  const navigate = useNavigate();
+  useMeta({ title: 'Crew Settings - Stylefolks' });
+  const [members, setMembers] = useState<CrewMember[]>([]);
+  const [tabs, setTabs] = useState<CrewTab[]>([]);
+  const [search, setSearch] = useState('');
+
+  useEffect(() => {
+    if (!crewId) return;
+    fetchCrewMembers(crewId).then(setMembers).catch(() => {});
+    fetchCrewTabs(crewId).then(setTabs).catch(() => {});
+  }, [crewId]);
+
+  const filtered = members.filter((m) =>
+    m.nickname.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  const changeRole = (userId: string, role: CrewRole) => {
+    if (!crewId) return;
+    updateCrewMemberRole(crewId, userId, role)
+      .then(() =>
+        setMembers((ms) => ms.map((m) => (m.userId === userId ? { ...m, role } : m))),
+      )
+      .catch(() => {});
+  };
+
+  const remove = (userId: string) => {
+    if (!crewId) return;
+    if (!window.confirm('정말 삭제하시겠습니까?')) return;
+    removeCrewMember(crewId, userId)
+      .then(() => setMembers((ms) => ms.filter((m) => m.userId !== userId)))
+      .catch(() => {});
+  };
+
+  const saveTabs = () => {
+    if (!crewId) return;
+    updateCrewTabs(crewId, tabs)
+      .then(() => navigate(`/crew/${crewId}/posts`))
+      .catch(() => {});
+  };
+
+  return (
+    <div className="p-4 space-y-6">
+      <h1 className="text-lg font-bold">Crew Settings</h1>
+      <section className="space-y-2">
+        <h2 className="font-semibold">Member management</h2>
+        <Input
+          placeholder="Search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <ul className="space-y-2">
+          {filtered.map((m) => (
+            <li key={m.userId} className="flex items-center gap-2">
+              <span className="flex-1 text-sm">{m.nickname}</span>
+              <Badge>{m.role.toUpperCase()}</Badge>
+              {m.role !== 'owner' && (
+                <>
+                  <select
+                    className="border rounded px-1 text-sm"
+                    value={m.role}
+                    onChange={(e) => changeRole(m.userId, e.target.value as CrewRole)}
+                  >
+                    <option value="manager">manager</option>
+                    <option value="member">member</option>
+                  </select>
+                  <Button variant="outline" size="sm" onClick={() => remove(m.userId)}>
+                    Delete
+                  </Button>
+                </>
+              )}
+            </li>
+          ))}
+        </ul>
+      </section>
+      <section className="space-y-2">
+        <h2 className="font-semibold">Tab management</h2>
+        <ul className="space-y-2">
+          {tabs.map((t, i) => (
+            <li key={t.id} className="flex items-center gap-2">
+              <span className="flex-1">
+                <Input
+                  value={t.title}
+                  onChange={(e) =>
+                    setTabs((tabs) =>
+                      tabs.map((tab) => (tab.id === t.id ? { ...tab, title: e.target.value } : tab)),
+                    )
+                  }
+                />
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setTabs((tabs) => tabs.filter((tab) => tab.id !== t.id))}
+              >
+                Delete
+              </Button>
+            </li>
+          ))}
+        </ul>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() =>
+            setTabs((ts) => [
+              ...ts,
+              {
+                id: Date.now(),
+                crewId: Number(crewId),
+                title: '',
+                type: 'topic',
+                isVisible: true,
+                order: ts.length,
+              },
+            ])
+          }
+        >
+          Add Tab
+        </Button>
+      </section>
+      <div className="flex gap-2">
+        <Button onClick={saveTabs}>Save</Button>
+        <Button variant="outline" onClick={() => navigate(-1)}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add crew settings page at `/crew/:crewId/settings`
- support member role updates, removal, and tab editing
- expose crew member APIs in `lib/crew`
- mock crew member endpoints in msw handlers
- register new route in App

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686744d40e388320bd7ed77e6d906ba3