### PR TITLE
Implement crew tab type options

### DIFF
--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -677,7 +677,7 @@ export const handlers = [
           type: "topic",
           isVisible: true,
           order: 4,
-          hashtag: "tag1",
+          hashtags: ["#tag1"],
         },
       ];
     }


### PR DESCRIPTION
## Summary
- let crew settings manage each tab's type
- save topic hashtags
- enforce unique non-topic tabs and limit topics to 3
- support drag-and-drop tab ordering
- update msw data for new hashtags field

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686756aef4688320968bd36e64d4e7fc