### PR TITLE
Implement Masonry PostCard layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 - [ ] Latest Posts
   - [x] 최신순으로 글 Infinite scroll
   - [x] 클릭 시 게시글 상세로 이동
-  - [ ] 게시글은 Masonary UI + 좋아요 수 + 작성자 이름 + 게시글 타이틀 보여주기
+  - [x] 게시글은 Masonary UI + 좋아요 수 + 작성자 이름 + 게시글 타이틀 보여주기
 
 ## 크루 디렉토리
 
@@ -45,8 +45,8 @@
   - [x] Tab(전체, Basic, Column) 클릭 시 posts?tab=탭이름
 - [x] Hashtags
   - [x] 조인 가장 많이된 해시태그 10개 렌더, 클릭 시 posts?tags=태그명1,태그명2...
-- [ ] 게시글 카드들
-  - [ ] 게시글은 Masonary UI + 좋아요 수 + 작성자 이름 + 게시글 타이틀 보여주기
+- [x] 게시글 카드들
+  - [x] 게시글은 Masonary UI + 좋아요 수 + 작성자 이름 + 게시글 타이틀 보여주기
 
 ## 게시글 작성 페이지
 
@@ -84,9 +84,9 @@
   - [ ] 크루 Manager또는 Owner면 crew-settings로 넘어가는 UI보여주기
 - 크루 description
 - [ ] 미 가입인 경우 join버튼 가입인 경우 dismiss버튼 노출 (크루 description우측으로 이동 시키고 작은 아이콘으로 변경하기)
-- [ ] All Posts, Topic, Notice, Event 탭 UI 재 정립 필요
-  - [ ] All Posts : 게시글은 Masonary UI + 좋아요 수 + 작성자 이름 + 게시글 타이틀 보여주기
-  - [ ] Topic : 게시글은 Masonary UI + 좋아요 수 + 작성자 이름 + 게시글 타이틀 보여주기
+  - [ ] All Posts, Topic, Notice, Event 탭 UI 재 정립 필요
+  - [x] All Posts : 게시글은 Masonary UI + 좋아요 수 + 작성자 이름 + 게시글 타이틀 보여주기
+  - [x] Topic : 게시글은 Masonary UI + 좋아요 수 + 작성자 이름 + 게시글 타이틀 보여주기
   - [ ] Notice : 게시글은 좌측 작은 이미지 중간 타이틀 우측 덧글 개수 및 좋아요 개수 간단하게 렌더 (테이블 형태의 리스트로 렌더)
   - [ ] Event : 게시글은 좌측 작은 이미지 중간 타이틀 우측 덧글 개수 및 좋아요 개수 간단하게 렌더 (나중에 위치 멘션 넣으면 위치도 렌더되도록 하자)
 

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -11,36 +11,46 @@ interface Props {
 }
 
 export default function PostCard({ post, withTitle = true }: Props) {
-  // Height based on id for consistent randomness
   const navigate = useNavigate();
-  const height = 150 + (post.id % 3) * 50;
 
   return (
-    <div className="mb-4 block w-full transition-opacity hover:opacity-80">
-      <div
-        style={{ height, viewTransitionName: `post-${post.id}` }}
-        className="relative w-full overflow-hidden rounded-lg bg-gray-100 cursor-pointer"
-        onClick={() => navigate(`/posts/${post.id}`)}
-      >
-        {post.image ? (
-          <>
-            <ImageWithSkeleton
-              src={post.image}
-              alt={post.title}
-              className="h-full w-full"
-            />
-          </>
-        ) : (
-          <Skeleton className={cn("absolute inset-0")} />
-        )}
-      </div>
-      <div className="flex items-center justify-between mt-2 text-sm opacity-80">
-        <Heart size={14} /> {post.likeCount}
-      {withTitle && (
-        <h3 className="text-sm font-medium text-black text-center w-full">
-          {post.title}
-        </h3>
+    <div
+      onClick={() => navigate(`/posts/${post.id}`)}
+      className="mb-4 break-inside-avoid cursor-pointer overflow-hidden rounded-xl bg-white shadow-md transition-opacity hover:opacity-80"
+    >
+      {post.image ? (
+        <ImageWithSkeleton
+          src={post.image}
+          alt={post.title}
+          className="aspect-[4/5] w-full"
+        />
+      ) : (
+        <div className="aspect-[4/5] w-full">
+          <Skeleton className="h-full w-full" />
+        </div>
       )}
+      <div className="space-y-1 p-3">
+        {withTitle && (
+          <div className="text-sm font-semibold text-black">{post.title}</div>
+        )}
+        <div className="flex items-center justify-between text-sm text-neutral-500">
+          <span className="flex items-center gap-1">
+            <span role="img" aria-label="likes">
+              ❤️
+            </span>
+            {post.likeCount}
+          </span>
+          <div className="flex items-center gap-1">
+            {post.author.imageUrl && (
+              <img
+                src={post.author.imageUrl}
+                alt={post.author.username}
+                className="h-5 w-5 rounded-full"
+              />
+            )}
+            <span className="text-xs">@{post.author.username}</span>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/PostGrid.tsx
+++ b/src/components/PostGrid.tsx
@@ -28,17 +28,10 @@ export default function PostGrid() {
 
   return (
     <>
-    <h2 className="text-l font-bold p-4">Latest Posts</h2>
-    <div className="columns-2 md:columns-3 gap-4 p-4">
+    <h2 className="p-4 text-l font-bold">Latest Posts</h2>
+    <div className="columns-2 gap-4 p-4 sm:columns-3">
       {posts.map((post) => (
-        <div
-          key={`post-${post.id}`}
-          className="break-inside-avoid"
-          // onClick={() => handlePostClick(String(post.id))}
-          style={{ cursor: 'pointer' }}
-        >
-          <PostCard post={post} />
-        </div>
+        <PostCard key={`post-${post.id}`} post={post} />
       ))}
       <div ref={ref} />
     </div>

--- a/src/components/crew/CrewFeedCard.tsx
+++ b/src/components/crew/CrewFeedCard.tsx
@@ -13,18 +13,24 @@ export interface CrewPost {
 export default function CrewFeedCard({ post }: { post: CrewPost }) {
   const firstTag = post.tags[0];
   return (
-    <Link to={`/posts/${post.id}`} className="block break-inside-avoid mb-4">
-      <div className="relative aspect-[4/5] w-full overflow-hidden rounded-md">
+    <Link
+      to={`/posts/${post.id}`}
+      className="mb-4 block break-inside-avoid overflow-hidden rounded-xl bg-white shadow-md"
+    >
+      <div className="relative aspect-[4/5] w-full overflow-hidden">
         <img src={post.imageUrl} alt={post.title} className="h-full w-full object-cover" />
         {firstTag && (
           <span className="absolute left-2 top-2 rounded-full bg-muted px-2 py-1 text-xs">#{firstTag}</span>
         )}
       </div>
-      <div className="mt-1 flex items-center justify-between text-sm text-muted-foreground">
-        <span>{post.author.nickname}</span>
-        <span className="flex items-center gap-1">
-          <Heart size={14} /> {post.likeCount}
-        </span>
+      <div className="space-y-1 p-3">
+        <div className="text-sm font-semibold text-black">{post.title}</div>
+        <div className="flex items-center justify-between text-sm text-neutral-500">
+          <span className="flex items-center gap-1">
+            <Heart size={14} /> {post.likeCount}
+          </span>
+          <span className="text-xs">{post.author.nickname}</span>
+        </div>
       </div>
     </Link>
   );

--- a/src/pages/CrewDetailPage.tsx
+++ b/src/pages/CrewDetailPage.tsx
@@ -93,7 +93,7 @@ export default function CrewDetailPage() {
         className="mt-4 px-4"
       />
       {tab === "all" && (
-        <div className="columns-2 gap-4 p-4" role="feed">
+        <div className="columns-2 gap-4 p-4 sm:columns-3" role="feed">
           {posts.map((post) => (
             <CrewFeedCard key={post.id} post={post} />
           ))}

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -57,9 +57,9 @@ export default function SearchPage() {
       {posts.length === 0 ? (
         <EmptyState />
       ) : (
-        <div className="grid grid-cols-2 gap-4">
+        <div className="columns-2 gap-4 sm:columns-3">
           {posts.map((post) => (
-            <PostCard withTitle={true} key={post.id} post={post} />
+            <PostCard key={post.id} post={post} />
           ))}
         </div>
       )}


### PR DESCRIPTION
## Summary
- redesign `PostCard` with masonry-friendly styles
- adjust `PostGrid`, `Search` page and crew components for masonry layout
- style crew feed cards
- show masonry posts in crew detail page
- mark related README tasks as complete

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868c761e0548320988cc2e4369f7472