### PR TITLE
Persist crew directory filters in URL

### DIFF
--- a/src/pages/CrewDirectoryPage.tsx
+++ b/src/pages/CrewDirectoryPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import { fetchCrews, type CrewSummary } from '@/lib/crew';
 import { useMeta } from '@/lib/meta';
 import { Button } from '@/components/ui/button';
@@ -9,15 +9,49 @@ import SearchInput from '@/components/crew-directory/SearchInput';
 
 export default function CrewDirectoryPage() {
   useMeta({ title: 'Crews Directory - Stylefolks' });
-  const [tag, setTag] = useState<string | null>(null);
-  const [keyword, setKeyword] = useState('');
-  const [debounced, setDebounced] = useState('');
+  const [searchParams, setSearchParams] = useSearchParams();
+  const initialTag = searchParams.get('tag');
+  const initialKeyword = searchParams.get('keyword') ?? '';
+
+  const [tag, setTag] = useState<string | null>(initialTag);
+  const [keyword, setKeyword] = useState(initialKeyword);
+  const [debounced, setDebounced] = useState(initialTag ? '' : initialKeyword);
   const [crews, setCrews] = useState<CrewSummary[]>([]);
 
   useEffect(() => {
     const id = setTimeout(() => setDebounced(keyword), 500);
     return () => clearTimeout(id);
   }, [keyword]);
+
+  useEffect(() => {
+    const params = new URLSearchParams(searchParams);
+    if (tag) {
+      params.set('tag', tag);
+      params.delete('keyword');
+    } else if (debounced) {
+      params.set('keyword', debounced);
+      params.delete('tag');
+    } else {
+      params.delete('tag');
+      params.delete('keyword');
+    }
+    if (params.toString() !== searchParams.toString()) {
+      setSearchParams(params);
+    }
+  }, [tag, debounced, searchParams, setSearchParams]);
+
+  useEffect(() => {
+    const t = searchParams.get('tag');
+    const kw = searchParams.get('keyword') ?? '';
+    setTag(t);
+    if (t) {
+      setKeyword('');
+      setDebounced('');
+    } else {
+      setKeyword(kw);
+      setDebounced(kw);
+    }
+  }, [searchParams]);
 
   useEffect(() => {
     const params: Record<string, string> = {};


### PR DESCRIPTION
## Summary
- restore original CrewDetailPage without URL sync
- sync search keyword or tag on CrewDirectoryPage with URL search params

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686b6caaa2c083208c95c10e81f7a522