### PR TITLE
Persist crew directory search filters in URL

### DIFF
--- a/src/lib/crewSearchParams.ts
+++ b/src/lib/crewSearchParams.ts
@@ -1,0 +1,21 @@
+export interface CrewSearchOptions {
+  keyword?: string;
+  tag?: string | null;
+}
+
+export function buildCrewSearchParams({ keyword, tag }: CrewSearchOptions): URLSearchParams {
+  const params = new URLSearchParams();
+  if (tag) {
+    params.set('tag', tag);
+  } else if (keyword) {
+    params.set('keyword', keyword);
+  }
+  return params;
+}
+
+export function parseCrewSearchParams(search: string | URLSearchParams): CrewSearchOptions {
+  const params = typeof search === 'string' ? new URLSearchParams(search) : search;
+  const keyword = params.get('keyword') ?? undefined;
+  const tag = params.get('tag');
+  return { keyword, tag };
+}


### PR DESCRIPTION
## Summary
- add helpers to build & parse search params for crew directory
- sync tag & keyword filters with URL search params

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686b74a685688320ae8e99f5ed5c3ded