### PR TITLE
Implement comment edit support

### DIFF
--- a/src/lib/postDetail.ts
+++ b/src/lib/postDetail.ts
@@ -5,7 +5,7 @@ export interface PostDetail {
   title: string;
   content: string;
   hashtags: string[];
-  author: { name: string; initials: string };
+  author: { userId: string; name: string; initials: string };
   createdAt: string;
   crewName: string;
   likes: number;
@@ -14,7 +14,7 @@ export interface PostDetail {
 
 export interface PostComment {
   id: string;
-  author: { name: string; initials: string };
+  author: { userId: string; name: string; initials: string };
   createdAt: string;
   content: string;
 }
@@ -52,4 +52,22 @@ export async function likePost(id: string): Promise<void> {
 export async function unlikePost(id: string): Promise<void> {
   const res = await fetch(`${API_BASE}/posts/${id}/unlike`, { method: 'DELETE' });
   if (!res.ok) throw new Error('Failed to unlike post');
+}
+
+export async function updatePostComment(
+  id: string,
+  content: string,
+): Promise<PostComment> {
+  const res = await fetch(`${API_BASE}/comment/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
+  });
+  if (!res.ok) throw new Error('Failed to update comment');
+  return res.json();
+}
+
+export async function deletePostComment(id: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/comment/${id}`, { method: 'DELETE' });
+  if (!res.ok) throw new Error('Failed to delete comment');
 }

--- a/tests/postDetail.test.ts
+++ b/tests/postDetail.test.ts
@@ -3,6 +3,8 @@ import {
   fetchPostDetail,
   fetchPostComments,
   addPostComment,
+  updatePostComment,
+  deletePostComment,
   likePost,
   unlikePost,
 } from '../src/lib/postDetail';
@@ -56,6 +58,26 @@ describe('post detail api', () => {
     await unlikePost('1');
     expect(global.fetch).toHaveBeenCalledWith(
       expect.stringContaining('/posts/1/unlike'),
+      expect.objectContaining({ method: 'DELETE' })
+    );
+  });
+
+  it('updatePostComment sends PATCH request', async () => {
+    await updatePostComment('c1', 'edit');
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/comment/c1'),
+      expect.objectContaining({
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: 'edit' }),
+      })
+    );
+  });
+
+  it('deletePostComment sends DELETE request', async () => {
+    await deletePostComment('c1');
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/comment/c1'),
       expect.objectContaining({ method: 'DELETE' })
     );
   });


### PR DESCRIPTION
## Summary
- add author user id to post and comment types
- patch and delete comments from post details
- link profile avatars/names to user profile
- allow editing or deleting own comments
- cover new comment APIs with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c84e6f1b88320820373ed2198c5ba