### PR TITLE
Implement follower modal

### DIFF
--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -16,10 +16,17 @@ export default function Modal({ open, onClose, children, className }: ModalProps
   };
   return createPortal(
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
       onClick={handleClick}
     >
-      <div className={cn('bg-white rounded p-4 w-full max-w-md m-4', className)}>{children}</div>
+      <div
+        className={cn(
+          'bg-white/70 backdrop-blur-md rounded p-4 w-full max-w-md m-4',
+          className,
+        )}
+      >
+        {children}
+      </div>
     </div>,
     document.body,
   );

--- a/src/pages/profile/[userId].tsx
+++ b/src/pages/profile/[userId].tsx
@@ -10,6 +10,7 @@ import {
   type SimpleUser,
 } from "@/lib/profile";
 import Avatar from "@/components/ui/avatar";
+import FollowListModal from "@/components/users/FollowListModal";
 import { logout } from "@/lib/auth";
 import { Menu } from "lucide-react";
 import { UserTier } from '@/constants/user';
@@ -94,13 +95,28 @@ export default function UserProfilePage() {
   const posts = profile.posts;
 
   return (
-    <div className="space-y-6 p-4">
-      <div className="relative flex flex-col items-center">
+    <>
+      <div className="space-y-6 p-4">
+        <div className="relative flex flex-col items-center">
         <Avatar src={profile.imageUrl} className="h-16 w-16" />
         <h2 className="mt-2 text-xl font-bold">{profile.username}</h2>
         <p className="text-sm text-gray-500">{profile.bio}</p>
         <p className="mt-1 text-sm">
-          {followers.length} followers · {following.length} following
+          <span
+            className="cursor-pointer hover:underline"
+            onClick={() => setModal("followers")}
+          >
+            {followers.length} followers
+          </span>
+          {' '}
+          ·
+          {' '}
+          <span
+            className="cursor-pointer hover:underline"
+            onClick={() => setModal("following")}
+          >
+            {following.length} following
+          </span>
         </p>
         <button
           aria-label="menu"
@@ -151,6 +167,21 @@ export default function UserProfilePage() {
           ))}
         </div>
       </div>
-    </div>
+      </div>
+      <FollowListModal
+        open={modal === "followers"}
+        onClose={() => setModal(null)}
+        users={followers}
+        type="followers"
+        isMaster={isMaster}
+      />
+      <FollowListModal
+        open={modal === "following"}
+        onClose={() => setModal(null)}
+        users={following}
+        type="following"
+        isMaster={isMaster}
+      />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- add glass effect styling to Modal
- show follower/following lists from profile page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686cb76e60048320b9e76d5861294dc3