### PR TITLE
Add notice UI and fix duplicate exports

### DIFF
--- a/src/lib/postDetail.ts
+++ b/src/lib/postDetail.ts
@@ -75,21 +75,3 @@ export async function deletePostComment(id: string): Promise<void> {
   const res = await fetch(`${API_BASE}/comment/${id}`, { method: 'DELETE' });
   if (!res.ok) throw new Error('Failed to delete comment');
 }
-
-export async function updatePostComment(
-  id: string,
-  content: string,
-): Promise<PostComment> {
-  const res = await fetch(`${API_BASE}/comment/${id}`, {
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ content }),
-  });
-  if (!res.ok) throw new Error('Failed to update comment');
-  return res.json();
-}
-
-export async function deletePostComment(id: string): Promise<void> {
-  const res = await fetch(`${API_BASE}/comment/${id}`, { method: 'DELETE' });
-  if (!res.ok) throw new Error('Failed to delete comment');
-}

--- a/src/pages/CrewDetailPage.tsx
+++ b/src/pages/CrewDetailPage.tsx
@@ -19,6 +19,45 @@ export interface TabItem {
   label: string;
 }
 
+interface NoticeItem {
+  title: string;
+  isNew: boolean;
+  author: string;
+  time: string;
+  views: number;
+}
+
+const demoNotices: NoticeItem[] = [
+  {
+    title: "New Feature Released",
+    isNew: true,
+    author: "David",
+    time: "2 hours ago",
+    views: 150,
+  },
+  {
+    title: "Scheduled Maintenance",
+    isNew: true,
+    author: "Sarah",
+    time: "5 hours ago",
+    views: 112,
+  },
+  {
+    title: "Community Guidelines",
+    isNew: true,
+    author: "John",
+    time: "1 day ago",
+    views: 98,
+  },
+  {
+    title: "Welcome to the Community!",
+    isNew: true,
+    author: "Emma",
+    time: "2 days ago",
+    views: 205,
+  },
+];
+
 export default function CrewDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -113,8 +152,31 @@ export default function CrewDetailPage() {
         </div>
       )}
       {tab === "NOTICE" && (
-        <div>
-          <p className="p-4">공지글입니다.</p>
+        <div className="flex justify-center p-4">
+          <div className="w-full max-w-[400px] space-y-4">
+            {demoNotices.map((notice, idx) => (
+              <div key={idx}>
+                <div className="rounded-2xl bg-white p-6 shadow-md">
+                  <div className="flex items-center">
+                    <h3 className="flex-1 text-lg font-bold">{notice.title}</h3>
+                    {notice.isNew && (
+                      <span className="ml-2 rounded-full bg-red-500 px-2 text-xs font-bold text-white">
+                        N
+                      </span>
+                    )}
+                  </div>
+                  <div className="mt-1 flex justify-between text-xs text-gray-500">
+                    <span>{notice.author}</span>
+                    <span>{notice.time}</span>
+                    <span>{notice.views} views</span>
+                  </div>
+                </div>
+                {idx < demoNotices.length - 1 && (
+                  <div className="my-4 h-px bg-gray-200" />
+                )}
+              </div>
+            ))}
+          </div>
         </div>
       )}
       {tab === "OVERVIEW" && (


### PR DESCRIPTION
## Summary
- implement modern notice tab for crews
- clean up duplicate exports in postDetail util

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686dd844a66083209346a31bad64fc16