### PR TITLE
Add crew description fetch

### DIFF
--- a/src/lib/crew.ts
+++ b/src/lib/crew.ts
@@ -73,6 +73,15 @@ export async function fetchCrew(id: string): Promise<Crew> {
   return res.json();
 }
 
+export async function fetchCrewDescription(id: string): Promise<string> {
+  const res = await fetch(`${API_BASE}/crews/${id}/description`, {
+    cache: "no-store",
+  });
+  if (!res.ok) throw new Error("Failed to load description");
+  const data = await res.json();
+  return data.description as string;
+}
+
 export async function fetchCrewPosts(
   id: string,
   topics: string[] = []

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -560,6 +560,22 @@ export const handlers = [
     });
   }),
 
+  http.get(`${API_BASE}/crews/:id/description`, ({ params }) => {
+    const { id } = params as { id: string };
+    if (id === "crew-1") {
+      return HttpResponse.json({
+        description: "Street fashion crew in Shinchon, Seoul.",
+      });
+    }
+    const found = createdCrews.find((c) => c.id === id);
+    if (found) {
+      return HttpResponse.json({ description: found.description });
+    }
+    return HttpResponse.json({
+      description: `This is crew ${id} description`,
+    });
+  }),
+
   http.get(`${API_BASE}/crews/:id/posts`, ({ params }) => {
     const { id } = params as { id: string };
     const posts = Array.from({ length: 4 }, (_, i) => {

--- a/src/pages/CrewDetailPage.tsx
+++ b/src/pages/CrewDetailPage.tsx
@@ -29,6 +29,7 @@ export default function CrewDetailPage() {
   const [posts, setPosts] = useState<Post[]>([]);
   const [events, setEvents] = useState<Event[]>([]);
   const [notices, setNotices] = useState<Notice[]>([]);
+  const [description, setDescription] = useState<string>("");
   const [tab, setTab] = useState<CrewMetaType>("POSTS");
   const [me, setMe] = useState<{ avatarUrl: string } | null>(null);
 
@@ -56,6 +57,10 @@ export default function CrewDetailPage() {
     fetch(`/crews/${id}/notices`)
       .then((res) => res.json())
       .then(setNotices)
+      .catch(() => {});
+    fetch(`/crews/${id}/description`)
+      .then((res) => res.json())
+      .then((data) => setDescription(data.description))
       .catch(() => {});
   }, [id]);
 
@@ -155,7 +160,7 @@ export default function CrewDetailPage() {
       )}
       {tab === "OVERVIEW" && (
         <div>
-          <p className="p-4">소개글입니다.</p>
+          <p className="p-4">{description}</p>
         </div>
       )}
       {tab === "EVENT" && (


### PR DESCRIPTION
## Summary
- fetch description from `/crews/:id/description` in CrewDetailPage
- show fetched description in Overview tab
- add helper `fetchCrewDescription`
- mock description API endpoint in MSW

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686df0e046ec8320b6651a0ffb7d2241